### PR TITLE
Site-wide visual refresh: design system + card grid + floating TOCs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : #"Sunpill/Sunpill.github.io" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 teaser                   : /assets/images/ksp.jpg
 logo                     : # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
-masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
+masthead_title           : "C&A Lab" # overrides the website title displayed in the masthead, use " " for no title
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links
 main:
   - title: "About us"
-    url: https://Cryptology-Algorithm-Lab.github.io
+    url: /
   - title: "Members"
     url: /Members/
   - title: "Projects"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,17 @@
+<div class="page__footer-identity">
+  <div class="cna-footer-lead">
+    <b>Cryptology &amp; Algorithm Lab</b>
+    &nbsp;·&nbsp; Department of Mathematics
+    &nbsp;·&nbsp; Hanyang University, Seoul, Korea
+  </div>
+  <div class="cna-footer-meta">
+    PI: <a href="https://sites.google.com/site/jhsbhs/">Prof. Jae Hong Seo</a>
+    &nbsp;·&nbsp; <a href="mailto:jaehongseo@hanyang.ac.kr">jaehongseo@hanyang.ac.kr</a>
+  </div>
+</div>
+
 <div class="page__footer-follow">
   <ul class="social-icons">
-    {% if site.data.ui-text[site.locale].follow_label %}
-      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
-    {% endif %}
-
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}
@@ -11,9 +19,8 @@
         {% endif %}
       {% endfor %}
     {% endif %}
-
     <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} Cryptology &amp; Algorithm Lab. Built with <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a>.</div>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,83 @@
 <!-- start custom footer snippets -->
-<p align="right"><A href="https://sites.google.com/view/hucc/"><img src="/assets/images/hucc.png"></A>
+<p align="right"><A href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer"><img src="/assets/images/hucc.png"></A></p>
+
+<script>
+(function () {
+  /* round-9 #1: open every off-site link in a new tab so the user
+     doesn't leave the homepage. Same-host and anchor (#) links are
+     left alone so in-page nav and scrollspy work as expected. */
+  document.querySelectorAll('a[href]').forEach(function (a) {
+    var href = a.getAttribute('href');
+    if (!href || href.charAt(0) === '#' || href.indexOf('mailto:') === 0) return;
+    if (a.hostname && a.hostname !== window.location.hostname) {
+      a.setAttribute('target', '_blank');
+      var rel = (a.getAttribute('rel') || '').split(/\s+/);
+      if (rel.indexOf('noopener') === -1) rel.push('noopener');
+      if (rel.indexOf('noreferrer') === -1) rel.push('noreferrer');
+      a.setAttribute('rel', rel.filter(Boolean).join(' '));
+    }
+  });
+
+  /* round-9 #2: scrollspy for the homepage floating section TOC.
+     Watches every h1/h2 inside .page__content and toggles
+     .is-active on the matching .cna-page-toc-item link. */
+  var toc = document.querySelector('.cna-page-toc');
+  if (!toc) return;
+  var items = toc.querySelectorAll('.cna-page-toc-item');
+  var targets = [];
+  items.forEach(function (it) {
+    var sel = it.getAttribute('href');
+    if (!sel || sel.charAt(0) !== '#') return;
+    var node = document.querySelector(sel);
+    if (node) targets.push({ id: sel.slice(1), node: node, item: it });
+  });
+  if (!targets.length) return;
+
+  function setActive(id) {
+    items.forEach(function (it) { it.classList.remove('is-active'); });
+    var match = targets.find(function (t) { return t.id === id; });
+    if (match) match.item.classList.add('is-active');
+  }
+
+  if ('IntersectionObserver' in window) {
+    var io = new IntersectionObserver(function (entries) {
+      /* Pick the entry closest to the top of the viewport that is currently
+         intersecting. Falls back to last seen section while scrolling past. */
+      var visible = entries
+        .filter(function (e) { return e.isIntersecting; })
+        .sort(function (a, b) { return a.boundingClientRect.top - b.boundingClientRect.top; });
+      if (visible.length) setActive(visible[0].target.id);
+    }, {
+      rootMargin: '-30% 0px -55% 0px',
+      threshold: 0
+    });
+    targets.forEach(function (t) { io.observe(t.node); });
+  } else {
+    /* fall back: highlight whichever section header has been scrolled past most recently */
+    window.addEventListener('scroll', function () {
+      var scrollY = window.scrollY + window.innerHeight * 0.3;
+      var current = targets[0];
+      targets.forEach(function (t) {
+        if (t.node.offsetTop <= scrollY) current = t;
+      });
+      setActive(current.id);
+    });
+  }
+
+  /* Smooth scroll on TOC click; account for sticky masthead offset */
+  items.forEach(function (it) {
+    it.addEventListener('click', function (e) {
+      var sel = it.getAttribute('href');
+      if (!sel || sel.charAt(0) !== '#') return;
+      var node = document.querySelector(sel);
+      if (!node) return;
+      e.preventDefault();
+      var headerOffset = 80;
+      var top = node.getBoundingClientRect().top + window.scrollY - headerOffset;
+      window.scrollTo({ top: top, behavior: 'smooth' });
+      history.replaceState(null, '', sel);
+    });
+  });
+})();
+</script>
 <!-- end custom footer snippets -->

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -526,6 +526,193 @@
   .cna-card{ padding: var(--cna-s-4); }
 }
 
+/* ──────────────────────────────────────────────────────────
+   12. THEME HARMONIZATION
+   Overrides minimal-mistakes chrome (body, masthead, hero,
+   content headings, links, footer) to harmonize with the
+   card design system. Scoped narrowly; no theme files touched.
+   ────────────────────────────────────────────────────────── */
+
+/* warm off-white page surface so cards visually separate */
+body{
+  background-color: var(--cna-bg);
+  color: var(--cna-ink);
+}
+.initial-content,
+.search-content{
+  background-color: var(--cna-bg);
+}
+.page__content{
+  background-color: transparent;
+}
+
+/* top nav (masthead) — thin warm rule, off-white surface */
+.masthead{
+  background-color: var(--cna-paper);
+  border-bottom: 1px solid var(--cna-line);
+  box-shadow: 0 1px 2px rgba(31,34,39,.03);
+}
+.masthead__inner-wrap{
+  padding-top: var(--cna-s-3);
+  padding-bottom: var(--cna-s-3);
+}
+.greedy-nav,
+.greedy-nav .visible-links a{
+  background: transparent;
+  color: var(--cna-ink);
+  font-weight: 500;
+}
+.greedy-nav .visible-links a:before{
+  background: var(--cna-indigo);
+  height: 2px;
+}
+.greedy-nav .site-title{
+  color: var(--cna-ink);
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+.greedy-nav button{
+  background: transparent;
+  color: var(--cna-ink);
+}
+.greedy-nav .hidden-links{
+  background: var(--cna-paper);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-md);
+  box-shadow: var(--cna-shadow-sm);
+}
+.greedy-nav .hidden-links a{
+  color: var(--cna-ink);
+}
+.greedy-nav .hidden-links a:hover{
+  background: var(--cna-bg);
+  color: var(--cna-indigo);
+}
+
+/* hero overlay — keep the dark warm tint, but polish title typography */
+.page__hero--overlay{
+  padding: 4em 0 5em;
+}
+.page__hero--overlay .page__title{
+  font-size: 2.4rem !important;
+  font-weight: 800;
+  letter-spacing: -.02em;
+  margin-bottom: var(--cna-s-2);
+}
+.page__hero--overlay .page__lead{
+  font-size: var(--cna-fs-md);
+  font-weight: 400;
+  opacity: .92;
+  letter-spacing: .01em;
+}
+
+/* page content — top h1, in-body h2/h3, paragraphs, links */
+.page__content > h1:first-child{
+  font-size: var(--cna-fs-2xl);
+  font-weight: 800;
+  letter-spacing: -.015em;
+  color: var(--cna-ink);
+  border: none;
+  padding-bottom: 0;
+  margin: var(--cna-s-2) 0 var(--cna-s-5);
+}
+.page__content h2{
+  font-size: var(--cna-fs-xl);
+  font-weight: 700;
+  letter-spacing: -.005em;
+  color: var(--cna-ink);
+  border: none;
+  padding-bottom: var(--cna-s-2);
+  margin: var(--cna-s-8) 0 var(--cna-s-4);
+  border-bottom: 1px solid var(--cna-rule);
+}
+.page__content h3{
+  font-size: var(--cna-fs-lg);
+  font-weight: 700;
+  color: var(--cna-ink);
+  border: none;
+  margin: var(--cna-s-6) 0 var(--cna-s-3);
+}
+.page__content > p{
+  font-size: var(--cna-fs-base);
+  line-height: 1.7;
+  color: var(--cna-ink);
+}
+.page__content > p a,
+.page__content > ul a,
+.page__content > ol a{
+  color: var(--cna-indigo);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--cna-dur) var(--cna-ease);
+}
+.page__content > p a:hover,
+.page__content > ul a:hover,
+.page__content > ol a:hover{
+  border-bottom-color: var(--cna-indigo);
+}
+
+/* strong / b inside flowing prose */
+.page__content > p strong,
+.page__content > p b{
+  font-weight: 700;
+  color: var(--cna-ink);
+}
+
+/* footer */
+.page__footer{
+  background-color: var(--cna-paper);
+  border-top: 1px solid var(--cna-line);
+  color: var(--cna-soft);
+}
+.page__footer-copyright{
+  font-size: var(--cna-fs-xs);
+  color: var(--cna-faint);
+  letter-spacing: .02em;
+}
+.page__footer-copyright a{
+  color: var(--cna-soft);
+}
+.page__footer-copyright a:hover{
+  color: var(--cna-ink);
+}
+.page__footer-follow{
+  padding-bottom: var(--cna-s-3);
+}
+.page__footer-follow .social-icons a{
+  color: var(--cna-soft);
+}
+.page__footer-follow .social-icons a:hover{
+  color: var(--cna-indigo);
+}
+
+/* breadcrumbs / nav rail / sidebar — subtle ink */
+.sidebar,
+.nav__list{
+  color: var(--cna-soft);
+  font-size: var(--cna-fs-sm);
+}
+.nav__list .nav__items a{
+  color: var(--cna-soft);
+}
+.nav__list .nav__items a:hover,
+.nav__list .nav__items .active{
+  color: var(--cna-indigo);
+}
+
+/* tighten splash layout body padding so cards sit closer to hero */
+.layout--splash .page__content{
+  padding-top: var(--cna-s-5);
+}
+
+/* mobile chrome */
+@media (max-width: 760px){
+  .page__hero--overlay{ padding: 3em 0 3.5em; }
+  .page__hero--overlay .page__title{ font-size: 1.9rem !important; }
+  .page__content h2{ font-size: var(--cna-fs-lg); margin-top: var(--cna-s-6); }
+  .page__content h3{ font-size: var(--cna-fs-md); }
+}
+
 </style>
 
 <!-- end custom head snippets -->

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -711,10 +711,25 @@ body{
 }
 .nav__list .nav__items a{
   color: var(--cna-soft);
+  text-decoration: none;
+  border-radius: 6px;
+  padding: 4px 8px;
+  display: block;
+  transition: background var(--cna-dur) var(--cna-ease), color var(--cna-dur) var(--cna-ease);
 }
-.nav__list .nav__items a:hover,
-.nav__list .nav__items .active{
+.nav__list .nav__items a:hover{
   color: var(--cna-indigo);
+  background: var(--cna-bg);
+}
+/* round-9 #2: highlighted current sub-page in News sidebar (and any
+   sidebar nav using the docs collection). */
+.nav__list .nav__items a.active,
+.nav__list .nav__items a[aria-current="page"]{
+  color: var(--cna-indigo);
+  font-weight: 700;
+  background: var(--cna-indigo-wash);
+  border-left: 3px solid var(--cna-indigo);
+  padding-left: 8px;
 }
 
 /* tighten splash layout body padding so cards sit closer to hero */
@@ -800,6 +815,64 @@ body{
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+}
+
+/* ──────────────────────────────────────────────────────────
+   15. FLOATING PAGE TOC (round-9)
+   Small fixed widget on the right side of the homepage that
+   shows which section is currently in view. Hidden on narrow
+   viewports. Scrollspy via IntersectionObserver in
+   _includes/footer/custom.html.
+   ────────────────────────────────────────────────────────── */
+.cna-page-toc{
+  position: fixed;
+  top: 50%;
+  right: 18px;
+  transform: translateY(-50%);
+  display: flex; flex-direction: column;
+  gap: var(--cna-s-1);
+  z-index: 90;
+  padding: var(--cna-s-2);
+  background: rgba(255, 255, 255, .82);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-md);
+  box-shadow: var(--cna-shadow-sm);
+}
+.cna-page-toc-label{
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--cna-faint);
+  padding: 4px 8px 6px;
+}
+.cna-page-toc-item{
+  font-size: var(--cna-fs-sm);
+  color: var(--cna-soft);
+  text-decoration: none;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border-left: 2px solid transparent;
+  transition: color var(--cna-dur) var(--cna-ease),
+              background var(--cna-dur) var(--cna-ease),
+              border-color var(--cna-dur) var(--cna-ease);
+  white-space: nowrap;
+}
+.cna-page-toc-item:hover{
+  color: var(--cna-ink);
+  background: var(--cna-bg);
+}
+.cna-page-toc-item.is-active{
+  color: var(--cna-indigo);
+  font-weight: 700;
+  border-left-color: var(--cna-indigo);
+  background: var(--cna-indigo-wash);
+}
+/* hide TOC on narrow viewports — content is the priority there */
+@media (max-width: 1280px){
+  .cna-page-toc{ display: none; }
 }
 .cna-member-card{
   padding: var(--cna-s-5);

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -11,7 +11,7 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Yesteryear&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500&display=swap" rel="stylesheet">
 
 <style type="text/css">
 
@@ -343,10 +343,12 @@
   border-radius: var(--cna-radius-pill);
 }
 .cna-member-motto{
-  font-family: 'Yesteryear', cursive;
-  font-size: var(--cna-fs-xl);
-  color: var(--cna-amber);
-  line-height: 1.15; margin-top: 8px;
+  font-family: 'Caveat', cursive;
+  font-size: 28px;
+  font-weight: 500;
+  color: var(--cna-soft);
+  line-height: 1.2; margin-top: 8px;
+  letter-spacing: .01em;
 }
 .cna-member-interests{
   font-size: var(--cna-fs-sm); color: var(--cna-soft);
@@ -533,14 +535,18 @@
    card design system. Scoped narrowly; no theme files touched.
    ────────────────────────────────────────────────────────── */
 
-/* warm off-white page surface so cards visually separate */
+/* round-5: pure white page surface — no beige overscroll bounce.
+   Cards rely on border (--cna-line) + shadow for separation. */
+html{
+  background-color: var(--cna-paper);
+}
 body{
-  background-color: var(--cna-bg);
+  background-color: var(--cna-paper);
   color: var(--cna-ink);
 }
 .initial-content,
 .search-content{
-  background-color: var(--cna-bg);
+  background-color: var(--cna-paper);
 }
 .page__content{
   background-color: transparent;
@@ -868,6 +874,40 @@ body{
   font-style: italic;
   opacity: .55;
   font-weight: 400;
+}
+
+/* round-5: active nav state — current section highlighted */
+.greedy-nav .visible-links a[aria-current="page"],
+.masthead__menu-item--active > a{
+  color: var(--cna-indigo);
+  font-weight: 700;
+}
+.greedy-nav .visible-links a[aria-current="page"]::before,
+.masthead__menu-item--active > a::before{
+  width: 100%;
+  background: var(--cna-indigo);
+  height: 2px;
+}
+
+/* round-5: honor award two-line layout — institution / recipients separated */
+.cna-row-recipients{
+  font-size: var(--cna-fs-sm);
+  color: var(--cna-soft);
+  line-height: 1.5;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--cna-rule);
+}
+.cna-row-recipients b{
+  color: var(--cna-ink);
+  font-weight: 600;
+}
+
+/* round-5: research area sections — unify to stone, dropping the per-area color
+   that previously clashed with the news-type / paper-venue palette */
+.cna-prose.cna-cat-people{
+  border-left: 3px solid var(--cna-stone-line);
+  padding-left: var(--cna-s-4);
 }
 
 /* (#12) Footer — replace minimal-mistakes default with a lab-identity block */

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,4 +2,530 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
+<!-- ============================================================
+     C&A Lab Design System v1  (2026-05-23)
+     Tokens + reusable component primitives.
+     All site-wide custom styles live here. Do not duplicate per page.
+     Reference: ~/lab-homepage-ops/proposals/design-20260523-v2-design-system.md
+============================================================ -->
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Yesteryear&display=swap" rel="stylesheet">
+
+<style type="text/css">
+
+/* ──────────────────────────────────────────────────────────
+   1. TOKENS
+   ────────────────────────────────────────────────────────── */
+:root{
+  /* category accents */
+  --cna-crimson:       #B6102D;
+  --cna-crimson-wash:  #FBE7EB;
+  --cna-crimson-line:  #E8B5BD;
+
+  --cna-indigo:        #2B5285;
+  --cna-indigo-wash:   #EAF1FA;
+  --cna-indigo-line:   #B9CCE3;
+
+  --cna-forest:        #176549;
+  --cna-forest-wash:   #E6F2EC;
+  --cna-forest-line:   #AECEC0;
+
+  --cna-amber:         #B8740A;
+  --cna-amber-wash:    #FDF4E3;
+  --cna-amber-line:    #E8C994;
+
+  --cna-stone:         #52575F;
+  --cna-stone-wash:    #EFEDE7;
+  --cna-stone-line:    #C8C2B2;
+
+  /* surface + ink */
+  --cna-ink:           #1F2227;
+  --cna-soft:          #52575F;
+  --cna-faint:         #8A909A;
+  --cna-paper:         #FFFFFF;
+  --cna-bg:            #FAFAF6;
+  --cna-line:          #E6E2D8;
+  --cna-rule:          #F0ECDF;
+
+  /* typography */
+  --cna-fs-xs:    12px;
+  --cna-fs-sm:    14px;
+  --cna-fs-base:  16px;
+  --cna-fs-md:    17px;
+  --cna-fs-lg:    19px;
+  --cna-fs-xl:    22px;
+  --cna-fs-2xl:   26px;
+
+  /* spacing 4-pt grid */
+  --cna-s-1:   4px;
+  --cna-s-2:   8px;
+  --cna-s-3:   12px;
+  --cna-s-4:   16px;
+  --cna-s-5:   20px;
+  --cna-s-6:   24px;
+  --cna-s-8:   32px;
+  --cna-s-10:  40px;
+
+  /* radius, shadow, motion */
+  --cna-radius-sm:    8px;
+  --cna-radius-md:    12px;
+  --cna-radius-lg:    14px;
+  --cna-radius-pill:  999px;
+  --cna-shadow-sm:    0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
+  --cna-shadow-md:    0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
+  --cna-ease:         cubic-bezier(.2,.7,.3,1);
+  --cna-dur:          .18s;
+}
+
+/* per-category accent shorthand (used inside .cna-cat-* containers) */
+.cna-cat-paper  { --cat: var(--cna-crimson); --cat-wash: var(--cna-crimson-wash); --cat-line: var(--cna-crimson-line); }
+.cna-cat-talk   { --cat: var(--cna-indigo);  --cat-wash: var(--cna-indigo-wash);  --cat-line: var(--cna-indigo-line);  }
+.cna-cat-award  { --cat: var(--cna-forest);  --cat-wash: var(--cna-forest-wash);  --cat-line: var(--cna-forest-line);  }
+.cna-cat-event  { --cat: var(--cna-amber);   --cat-wash: var(--cna-amber-wash);   --cat-line: var(--cna-amber-line);   }
+.cna-cat-people { --cat: var(--cna-stone);   --cat-wash: var(--cna-stone-wash);   --cat-line: var(--cna-stone-line);   }
+
+/* ──────────────────────────────────────────────────────────
+   2. SECTION
+   ────────────────────────────────────────────────────────── */
+.cna-section{ margin: var(--cna-s-8) 0; }
+.cna-section + .cna-section{ margin-top: var(--cna-s-10); }
+.cna-section-head{
+  display: flex; align-items: baseline; gap: var(--cna-s-3);
+  margin: 0 0 var(--cna-s-4);
+  padding-bottom: var(--cna-s-2);
+  border-bottom: 1px solid var(--cna-rule);
+}
+.cna-section-head h2,
+.cna-section-head h3{
+  margin: 0; padding: 0; border: none;
+  font-size: var(--cna-fs-2xl);
+  font-weight: 700; color: var(--cna-ink);
+  letter-spacing: -.005em;
+}
+.cna-section-head .cna-section-count{
+  font-size: var(--cna-fs-xs); color: var(--cna-soft); font-weight: 600;
+  padding: 2px 10px; background: var(--cna-stone-wash);
+  border-radius: var(--cna-radius-pill);
+  letter-spacing: .04em;
+}
+.cna-section-head .cna-section-action{
+  margin-left: auto;
+  font-size: var(--cna-fs-sm); color: var(--cna-soft);
+  text-decoration: none;
+}
+.cna-section-head .cna-section-action:hover{ color: var(--cna-ink); text-decoration: underline; }
+
+.cna-section.cna-cat-paper  .cna-section-head{ border-bottom-color: var(--cna-crimson-line); }
+.cna-section.cna-cat-talk   .cna-section-head{ border-bottom-color: var(--cna-indigo-line); }
+.cna-section.cna-cat-award  .cna-section-head{ border-bottom-color: var(--cna-forest-line); }
+.cna-section.cna-cat-event  .cna-section-head{ border-bottom-color: var(--cna-amber-line); }
+.cna-section.cna-cat-people .cna-section-head{ border-bottom-color: var(--cna-stone-line); }
+
+/* ──────────────────────────────────────────────────────────
+   3. CHIP
+   ────────────────────────────────────────────────────────── */
+.cna-chip{
+  display: inline-block;
+  font-size: var(--cna-fs-xs); font-weight: 700;
+  letter-spacing: .08em; text-transform: uppercase;
+  padding: 4px 10px; border-radius: var(--cna-radius-pill);
+  white-space: nowrap;
+  background: var(--cna-stone-wash); color: var(--cna-soft);
+  line-height: 1.4;
+}
+.cna-chip-paper  { background: var(--cna-crimson-wash); color: var(--cna-crimson); }
+.cna-chip-talk   { background: var(--cna-indigo-wash);  color: var(--cna-indigo);  }
+.cna-chip-award  { background: var(--cna-forest-wash);  color: var(--cna-forest);  }
+.cna-chip-event  { background: var(--cna-amber-wash);   color: var(--cna-amber);   }
+.cna-chip-people { background: var(--cna-stone-wash);   color: var(--cna-stone);   }
+
+.cna-chip-muted{
+  background: transparent; color: var(--cna-faint);
+  border: 1px solid var(--cna-line); font-weight: 600;
+}
+
+/* ──────────────────────────────────────────────────────────
+   4. CARD
+   ────────────────────────────────────────────────────────── */
+.cna-card{
+  background: var(--cna-paper);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-lg);
+  padding: var(--cna-s-5);
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform var(--cna-dur) var(--cna-ease),
+              box-shadow var(--cna-dur) var(--cna-ease),
+              border-color var(--cna-dur) var(--cna-ease);
+}
+.cna-card:hover{
+  transform: translateY(-2px);
+  box-shadow: var(--cna-shadow-md);
+}
+.cna-card.cna-cat-paper:hover  { border-color: var(--cna-crimson-line); }
+.cna-card.cna-cat-talk:hover   { border-color: var(--cna-indigo-line);  }
+.cna-card.cna-cat-award:hover  { border-color: var(--cna-forest-line);  }
+.cna-card.cna-cat-event:hover  { border-color: var(--cna-amber-line);   }
+.cna-card.cna-cat-people:hover { border-color: var(--cna-stone-line);   }
+
+.cna-card-head{
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--cna-s-3); margin-bottom: var(--cna-s-2);
+  flex-wrap: wrap;
+}
+.cna-card-meta{
+  font-size: var(--cna-fs-sm); color: var(--cna-faint);
+  font-weight: 500; white-space: nowrap; font-style: normal;
+}
+.cna-card-body{
+  font-size: var(--cna-fs-base); color: var(--cna-ink);
+  line-height: 1.6;
+}
+.cna-card-body p{ margin: 0 0 var(--cna-s-2); }
+.cna-card-body ul{ margin: var(--cna-s-2) 0 0; padding-left: 1.3em; }
+.cna-card-body ul li{ margin: 2px 0; }
+.cna-card-body details > summary{
+  cursor: pointer; color: var(--cna-soft);
+  font-size: var(--cna-fs-sm); font-weight: 500;
+}
+.cna-card-body img{
+  max-width: 100%; border-radius: var(--cna-radius-md);
+  margin-top: var(--cna-s-2);
+}
+
+.cna-card-grid{
+  display: grid; gap: var(--cna-s-4);
+  grid-template-columns: 1fr;
+  margin: var(--cna-s-3) 0 var(--cna-s-6);
+}
+
+/* ──────────────────────────────────────────────────────────
+   5. YEAR cluster (collapsible card with summary)
+   ────────────────────────────────────────────────────────── */
+.cna-year{
+  background: var(--cna-paper);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-lg);
+  margin: 0 0 var(--cna-s-3);
+  box-shadow: var(--cna-shadow-sm);
+  overflow: hidden;
+}
+.cna-year > summary{
+  cursor: pointer; user-select: none; list-style: none;
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--cna-s-3);
+  padding: var(--cna-s-4) var(--cna-s-5);
+  transition: background var(--cna-dur) var(--cna-ease);
+}
+.cna-year > summary::-webkit-details-marker{ display: none; }
+.cna-year > summary:hover{ background: rgba(0,0,0,.025); }
+.cna-year > summary > h3{
+  margin: 0; padding: 0; border: none;
+  font-size: var(--cna-fs-xl);
+  font-weight: 700; color: var(--cna-ink);
+}
+.cna-year-count{
+  font-size: var(--cna-fs-sm); color: var(--cna-faint);
+  font-weight: 500;
+}
+.cna-year-chevron{
+  width: 18px; height: 18px; flex: 0 0 18px;
+  color: var(--cna-faint);
+  transition: transform var(--cna-dur) var(--cna-ease);
+  margin-left: auto;
+}
+.cna-year[open] .cna-year-chevron{ transform: rotate(180deg); }
+.cna-year[open] > summary{
+  border-bottom: 1px solid var(--cna-rule);
+}
+.cna-year-body{
+  padding: var(--cna-s-3) var(--cna-s-5) var(--cna-s-4);
+}
+
+/* ──────────────────────────────────────────────────────────
+   6. ROW (generic list item: meta | main | aside)
+   ────────────────────────────────────────────────────────── */
+.cna-row{
+  display: grid;
+  grid-template-columns: 56px 1fr 200px;
+  gap: var(--cna-s-4);
+  align-items: start;
+  padding: var(--cna-s-3) 0;
+  border-bottom: 1px solid var(--cna-rule);
+}
+.cna-row:last-child{ border-bottom: none; }
+.cna-row-meta{
+  font-size: var(--cna-fs-xs); font-weight: 700;
+  letter-spacing: .04em; color: var(--cna-faint);
+  padding-top: 3px;
+}
+.cna-row-main{ min-width: 0; }
+.cna-row-title{
+  font-size: var(--cna-fs-base); color: var(--cna-ink); line-height: 1.5;
+}
+.cna-row-title i{ color: var(--cna-ink); }
+.cna-row-sub{
+  font-size: var(--cna-fs-sm); color: var(--cna-soft);
+  line-height: 1.5; margin-top: 3px;
+}
+.cna-row-sub i, .cna-row-sub em{ color: var(--cna-soft); }
+.cna-row-aside{
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; font-size: var(--cna-fs-xs);
+}
+.cna-row-aside-detail{
+  color: var(--cna-faint); font-size: var(--cna-fs-xs);
+  text-align: right; line-height: 1.4;
+}
+.cna-row-aside-detail a{ color: var(--cna-soft); }
+.cna-row-aside-detail a:hover{ color: var(--cna-ink); }
+
+/* ──────────────────────────────────────────────────────────
+   7. ROSTER + MEMBER
+   ────────────────────────────────────────────────────────── */
+.cna-roster{ margin: 0 0 var(--cna-s-6); }
+.cna-roster-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--cna-s-4);
+}
+
+.cna-member{
+  background: var(--cna-paper);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-lg);
+  overflow: hidden;
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform var(--cna-dur) var(--cna-ease),
+              box-shadow var(--cna-dur) var(--cna-ease),
+              border-color var(--cna-dur) var(--cna-ease);
+}
+.cna-member:hover{
+  transform: translateY(-2px);
+  box-shadow: var(--cna-shadow-md);
+  border-color: var(--cna-stone-line);
+}
+.cna-member[open]{ border-color: var(--cna-amber); }
+.cna-member > summary{
+  cursor: pointer; user-select: none; list-style: none; outline: none;
+}
+.cna-member > summary::-webkit-details-marker{ display: none; }
+
+.cna-member-card{
+  display: flex; gap: var(--cna-s-4);
+  padding: var(--cna-s-4);
+  align-items: flex-start;
+}
+.cna-member-photo{
+  width: 100px; height: 100px;
+  border-radius: var(--cna-radius-md);
+  object-fit: cover; flex: 0 0 100px;
+  background: var(--cna-bg);
+}
+.cna-member-meta{ min-width: 0; display: flex; flex-direction: column; gap: 3px; flex: 1; }
+.cna-member-name{
+  font-size: var(--cna-fs-lg); font-weight: 700;
+  color: var(--cna-ink); text-decoration: none;
+  line-height: 1.2;
+}
+.cna-member-name:hover{ text-decoration: underline; }
+.cna-member-name .cna-ext{
+  font-size: var(--cna-fs-xs); opacity: .55;
+  margin-left: 4px; font-weight: 500;
+}
+.cna-member-role{
+  font-size: var(--cna-fs-xs); color: var(--cna-soft);
+  letter-spacing: .08em; text-transform: uppercase;
+  font-weight: 700; margin-top: 4px;
+  align-self: flex-start;
+  padding: 3px 8px; background: var(--cna-stone-wash);
+  border-radius: var(--cna-radius-pill);
+}
+.cna-member-motto{
+  font-family: 'Yesteryear', cursive;
+  font-size: var(--cna-fs-xl);
+  color: var(--cna-amber);
+  line-height: 1.15; margin-top: 8px;
+}
+.cna-member-interests{
+  font-size: var(--cna-fs-sm); color: var(--cna-soft);
+  margin-top: 6px; line-height: 1.5;
+}
+
+.cna-member-bio{
+  padding: 0 var(--cna-s-5) var(--cna-s-4);
+  border-top: 1px solid var(--cna-rule);
+  font-size: var(--cna-fs-base); line-height: 1.6; color: var(--cna-ink);
+}
+.cna-member-bio h4{
+  font-size: var(--cna-fs-xs); letter-spacing: .1em;
+  text-transform: uppercase; color: var(--cna-faint);
+  font-weight: 700; margin: var(--cna-s-4) 0 var(--cna-s-2);
+  border: none; padding: 0;
+}
+.cna-member-bio p{ margin: 0 0 var(--cna-s-2); }
+.cna-member-bio ul{ padding-left: 1.2em; margin: 0; }
+.cna-member-bio li{ margin-bottom: 5px; }
+.cna-member-bio .cna-edu{ width: 100%; border-collapse: collapse; font-size: var(--cna-fs-sm); }
+.cna-member-bio .cna-edu td{ padding: 4px 0; border: none; vertical-align: top; }
+.cna-member-bio .cna-edu td:nth-child(1){ font-weight: 600; }
+.cna-member-bio .cna-edu td:nth-child(2){ color: var(--cna-soft); font-style: italic; padding: 0 var(--cna-s-3); }
+.cna-member-bio .cna-edu td:nth-child(3){ color: var(--cna-faint); font-size: var(--cna-fs-xs); text-align: right; white-space: nowrap; }
+
+/* alumni — denser, no photo */
+.cna-alumni-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 0 var(--cna-s-6);
+  margin-top: var(--cna-s-2);
+}
+.cna-alum{
+  font-size: var(--cna-fs-sm); color: var(--cna-ink);
+  padding: var(--cna-s-3) 0;
+  border-bottom: 1px solid var(--cna-rule);
+}
+.cna-alum-name{ font-weight: 700; }
+.cna-alum-affil{ color: var(--cna-soft); font-size: var(--cna-fs-sm); }
+.cna-alum-when{
+  display: block; color: var(--cna-faint);
+  font-size: var(--cna-fs-xs); margin-top: 2px;
+  letter-spacing: .04em;
+}
+
+/* ──────────────────────────────────────────────────────────
+   8. TALLY (Highlights counter row)
+   ────────────────────────────────────────────────────────── */
+.cna-tally{
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: var(--cna-s-2);
+  margin: var(--cna-s-2) 0 var(--cna-s-6);
+  padding: var(--cna-s-3) var(--cna-s-4);
+  background: var(--cna-bg);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-md);
+  font-size: var(--cna-fs-sm);
+}
+.cna-tally-label{
+  font-weight: 700; color: var(--cna-soft);
+  letter-spacing: .02em; margin-right: var(--cna-s-2);
+  font-size: var(--cna-fs-sm);
+}
+.cna-tally-pill{
+  font-size: var(--cna-fs-xs); font-weight: 700;
+  letter-spacing: .06em;
+  padding: 4px 10px; border-radius: var(--cna-radius-pill);
+  white-space: nowrap;
+  background: var(--cna-paper); color: var(--cna-ink);
+  border: 1px solid var(--cna-line);
+}
+.cna-tally-pill.cna-tally-paper  { color: var(--cna-crimson); border-color: var(--cna-crimson-line); }
+.cna-tally-pill.cna-tally-talk   { color: var(--cna-indigo);  border-color: var(--cna-indigo-line);  }
+.cna-tally-pill.cna-tally-award  { color: var(--cna-forest);  border-color: var(--cna-forest-line);  }
+.cna-tally-pill.cna-tally-event  { color: var(--cna-amber);   border-color: var(--cna-amber-line);   }
+.cna-tally-pill.cna-tally-people { color: var(--cna-stone);   border-color: var(--cna-stone-line);   }
+
+/* ──────────────────────────────────────────────────────────
+   9. PHOTO GRID (Gallery)
+   ────────────────────────────────────────────────────────── */
+.cna-photo-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--cna-s-3);
+  margin: var(--cna-s-3) 0 var(--cna-s-6);
+}
+.cna-photo{
+  position: relative; overflow: hidden;
+  border-radius: var(--cna-radius-md);
+  background: var(--cna-bg);
+  aspect-ratio: 4/3;
+  cursor: zoom-in;
+}
+.cna-photo img{
+  width: 100%; height: 100%; object-fit: cover;
+  transition: transform .3s var(--cna-ease);
+  display: block;
+}
+.cna-photo:hover img{ transform: scale(1.04); }
+.cna-photo-caption{
+  position: absolute; left: 0; right: 0; bottom: 0;
+  padding: var(--cna-s-3) var(--cna-s-4);
+  background: linear-gradient(to top, rgba(31,34,39,.75), rgba(31,34,39,0));
+  color: #fff; font-size: var(--cna-fs-sm); font-weight: 500;
+  opacity: 0; transition: opacity var(--cna-dur) var(--cna-ease);
+}
+.cna-photo:hover .cna-photo-caption{ opacity: 1; }
+
+/* ──────────────────────────────────────────────────────────
+   10. PROSE (long-form reading, for Interest descriptions)
+   ────────────────────────────────────────────────────────── */
+.cna-prose{
+  max-width: 70ch;
+  font-size: var(--cna-fs-base);
+  line-height: 1.7;
+  color: var(--cna-ink);
+}
+.cna-prose p{ margin: 0 0 var(--cna-s-4); }
+.cna-prose p:first-child{
+  font-size: var(--cna-fs-md);
+  color: var(--cna-soft);
+}
+.cna-prose a{ color: var(--cna-indigo); }
+.cna-prose a:hover{ color: var(--cna-indigo); text-decoration: underline; }
+.cna-prose img{
+  display: block; max-width: 100%;
+  margin: var(--cna-s-5) 0;
+  border-radius: var(--cna-radius-md);
+  box-shadow: var(--cna-shadow-sm);
+}
+.cna-prose .cna-learn-more{
+  display: block;
+  background: var(--cna-bg);
+  border: 1px solid var(--cna-line);
+  border-radius: var(--cna-radius-md);
+  padding: var(--cna-s-3) var(--cna-s-4);
+  margin: var(--cna-s-4) 0;
+  font-size: var(--cna-fs-sm);
+}
+.cna-prose .cna-learn-more > summary{
+  cursor: pointer; font-weight: 600;
+  color: var(--cna-ink); list-style: none;
+}
+.cna-prose .cna-learn-more > summary::-webkit-details-marker{ display: none; }
+.cna-prose .cna-learn-more > summary::before{
+  content: "▸"; margin-right: var(--cna-s-2);
+  color: var(--cna-faint);
+  transition: transform var(--cna-dur) var(--cna-ease);
+  display: inline-block;
+}
+.cna-prose .cna-learn-more[open] > summary::before{ transform: rotate(90deg); }
+.cna-prose .cna-learn-more[open]{ background: var(--cna-paper); }
+
+/* category-accented prose lead bar (left border) */
+.cna-prose.cna-cat-paper  { border-left: 3px solid var(--cna-crimson); padding-left: var(--cna-s-4); }
+.cna-prose.cna-cat-talk   { border-left: 3px solid var(--cna-indigo);  padding-left: var(--cna-s-4); }
+.cna-prose.cna-cat-award  { border-left: 3px solid var(--cna-forest);  padding-left: var(--cna-s-4); }
+.cna-prose.cna-cat-event  { border-left: 3px solid var(--cna-amber);   padding-left: var(--cna-s-4); }
+
+/* ──────────────────────────────────────────────────────────
+   11. MOBILE
+   ────────────────────────────────────────────────────────── */
+@media (max-width: 760px){
+  .cna-row{ grid-template-columns: 1fr; gap: var(--cna-s-2); }
+  .cna-row-aside{ flex-direction: row; flex-wrap: wrap; align-items: flex-start; gap: var(--cna-s-2); }
+  .cna-row-aside-detail{ text-align: left; }
+  .cna-roster-grid{ grid-template-columns: 1fr; }
+  .cna-member-card{ flex-direction: column; }
+  .cna-member-photo{ width: 110px; height: 110px; flex: 0 0 110px; }
+  .cna-alumni-grid{ grid-template-columns: 1fr; }
+  .cna-photo-grid{ grid-template-columns: 1fr; }
+  .cna-section-head h2,
+  .cna-section-head h3{ font-size: var(--cna-fs-xl); }
+  .cna-year > summary{ padding: var(--cna-s-3) var(--cna-s-4); }
+  .cna-year-body{ padding: var(--cna-s-3) var(--cna-s-4); }
+  .cna-card{ padding: var(--cna-s-4); }
+}
+
+</style>
+
 <!-- end custom head snippets -->

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -725,10 +725,32 @@ body{
    period column, full-width prose on Interest.
    ────────────────────────────────────────────────────────── */
 
-/* Members — bigger cards, larger photos, larger fonts */
+/* Members — bigger cards, larger photos, larger fonts.
+   round-6: auto-fit instead of auto-fill — when a section has only one
+   member (Prof, Postdoc, PhD, Master), the single card stretches to
+   span the full row instead of sitting in a 360px column with empty
+   space beside it. */
 .cna-roster-grid{
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
   gap: var(--cna-s-5);
+}
+/* For an OPEN member card that's the only one in its grid (solo
+   section like Professor), split into a 2-column layout: summary on
+   the left, bio on the right — so the wider card breathes instead of
+   leaving its right half empty. */
+@media (min-width: 900px){
+  .cna-member[open]:only-child{
+    display: grid;
+    grid-template-columns: minmax(380px, 0.55fr) 1fr;
+    gap: 0;
+  }
+  .cna-member[open]:only-child > summary{
+    border-right: 1px solid var(--cna-rule);
+  }
+  .cna-member[open]:only-child > .cna-member-bio{
+    border-top: none;
+    padding: var(--cna-s-5);
+  }
 }
 .cna-member-card{
   padding: var(--cna-s-5);

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -713,6 +713,82 @@ body{
   .page__content h3{ font-size: var(--cna-fs-md); }
 }
 
+/* ──────────────────────────────────────────────────────────
+   13. READABILITY TUNING (Members, Projects, Interest)
+   Per round-3 feedback: bigger member cards, wider project
+   period column, full-width prose on Interest.
+   ────────────────────────────────────────────────────────── */
+
+/* Members — bigger cards, larger photos, larger fonts */
+.cna-roster-grid{
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: var(--cna-s-5);
+}
+.cna-member-card{
+  padding: var(--cna-s-5);
+  gap: var(--cna-s-4);
+}
+.cna-member-photo{
+  width: 120px; height: 120px; flex: 0 0 120px;
+}
+.cna-member-name{
+  font-size: var(--cna-fs-xl);
+  font-weight: 700;
+}
+.cna-member-role{
+  font-size: var(--cna-fs-sm);
+  padding: 4px 10px;
+  margin-top: 6px;
+  letter-spacing: .06em;
+}
+.cna-member-motto{
+  font-size: var(--cna-fs-2xl);
+  line-height: 1.1;
+  margin-top: 10px;
+}
+.cna-member-interests{
+  font-size: var(--cna-fs-base);
+  margin-top: 10px;
+  line-height: 1.5;
+}
+.cna-member-bio{
+  padding: var(--cna-s-2) var(--cna-s-5) var(--cna-s-5);
+  font-size: var(--cna-fs-base);
+  line-height: 1.65;
+}
+.cna-member-bio h4{
+  font-size: var(--cna-fs-sm);
+  margin-top: var(--cna-s-5);
+}
+.cna-member-bio .cna-edu{ font-size: var(--cna-fs-base); }
+
+/* Projects — wider period column on one line, neutral chip override */
+.cna-projects .cna-row{
+  grid-template-columns: 160px 1fr 180px;
+}
+.cna-projects .cna-row-meta{
+  font-size: var(--cna-fs-sm);
+  font-weight: 600;
+  color: var(--cna-soft);
+  white-space: nowrap;
+  padding-top: 2px;
+  letter-spacing: 0;
+}
+@media (max-width: 760px){
+  .cna-projects .cna-row{ grid-template-columns: 1fr; }
+}
+
+/* Interest prose — use the full page content width */
+.cna-prose,
+.cna-prose p,
+.cna-prose ul,
+.cna-prose ol{
+  max-width: none;
+}
+.cna-prose img{
+  max-width: 100%;
+}
+
 </style>
 
 <!-- end custom head snippets -->

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -808,13 +808,24 @@ body{
 
 /* round-8: motto stays on one line whenever the card has full-row room
    — either as the sole member of its roster (auto-fit single-col) or
-   after being clicked open (grid-column: 1 / -1). Otherwise wraps. */
-.cna-roster-grid > .cna-member:only-child .cna-member-motto,
-.cna-member[open] .cna-member-motto{
+   after being clicked open (grid-column: 1 / -1). Otherwise wraps.
+   round-9 fix: EXCLUDE the Prof case (:only-child with bio → 2-col
+   split layout puts the meta column at ~220px which is too narrow
+   for the 28px Caveat motto — it'd truncate with '...'). Let motto
+   wrap there so the full quote is always readable. */
+.cna-roster-grid > .cna-member:only-child:not(:has(.cna-member-bio)) .cna-member-motto,
+.cna-member[open]:not(:only-child) .cna-member-motto{
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+}
+/* Prof case: allow motto to wrap, no ellipsis */
+.cna-member[open]:only-child:has(.cna-member-bio) .cna-member-motto{
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.15;
 }
 
 /* ──────────────────────────────────────────────────────────

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -737,11 +737,13 @@ body{
 /* For an OPEN member card that's the only one in its grid (solo
    section like Professor), split into a 2-column layout: summary on
    the left, bio on the right — so the wider card breathes instead of
-   leaving its right half empty. */
-@media (min-width: 900px){
+   leaving its right half empty. round-6: raise breakpoint to 1024px
+   so the bio side gets genuine room; use minmax for graceful
+   collapse on borderline widths. */
+@media (min-width: 1024px){
   .cna-member[open]:only-child{
     display: grid;
-    grid-template-columns: minmax(380px, 0.55fr) 1fr;
+    grid-template-columns: minmax(360px, 0.5fr) minmax(0, 1fr);
     gap: 0;
   }
   .cna-member[open]:only-child > summary{
@@ -751,6 +753,17 @@ body{
     border-top: none;
     padding: var(--cna-s-5);
   }
+}
+
+/* Lightweight opacity fade for the bio when a member card opens — gives
+   click feedback without trying to animate height (which <details>
+   can't do cleanly cross-browser). */
+.cna-member[open] > .cna-member-bio{
+  animation: cna-bio-fade .2s var(--cna-ease) both;
+}
+@keyframes cna-bio-fade{
+  from{ opacity: 0; }
+  to{   opacity: 1; }
 }
 .cna-member-card{
   padding: var(--cna-s-5);
@@ -843,6 +856,11 @@ body{
   text-transform: uppercase;
   opacity: .85;
 }
+/* Suppress on homepage — there the title IS the lab identity, eyebrow would be redundant */
+.layout--splash[data-page-class="home"] .page__hero--overlay .page__title::before,
+body.page--home .page__hero--overlay .page__title::before{
+  content: none;
+}
 /* (#3) Yesteryear motto — soften the amber to a desaturated warm gray so it stops shouting */
 .cna-member-motto{
   color: #8C6B3A;
@@ -898,7 +916,9 @@ body{
   font-weight: 400;
 }
 
-/* round-5: active nav state — current section highlighted */
+/* round-5: active nav state — current section highlighted.
+   round-6 fix: also override minimal-mistakes' default
+   transform: scaleX(0) so the underline actually shows. */
 .greedy-nav .visible-links a[aria-current="page"],
 .masthead__menu-item--active > a{
   color: var(--cna-indigo);
@@ -909,6 +929,10 @@ body{
   width: 100%;
   background: var(--cna-indigo);
   height: 2px;
+  transform: scaleX(1) translate3d(0, 0, 0);
+}
+.greedy-nav .visible-links a:hover{
+  color: var(--cna-soft);
 }
 
 /* round-5: honor award two-line layout — institution / recipients separated */

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -46,7 +46,7 @@
   --cna-faint:         #8A909A;
   --cna-paper:         #FFFFFF;
   --cna-bg:            #FAFAF6;
-  --cna-line:          #E6E2D8;
+  --cna-line:          #DDD7C8;   /* round-4: bump from #E6E2D8 for stronger card edge contrast vs --cna-bg */
   --cna-rule:          #F0ECDF;
 
   /* typography */
@@ -787,6 +787,114 @@ body{
 }
 .cna-prose img{
   max-width: 100%;
+}
+
+/* ──────────────────────────────────────────────────────────
+   14. AUDIT ROUND 4 — punch-list refinements
+   Per design review (2026-05-23): hero/eyebrow, motto color,
+   member open-state, empty-meta row variant, award-tier muted
+   chips, publication aside widen, seminar TBA cleanup.
+   ────────────────────────────────────────────────────────── */
+
+/* (#2) Hero — pull title size down, add an uppercase eyebrow above */
+.page__hero--overlay .page__title{
+  font-size: 2rem !important;
+  font-weight: 800;
+  letter-spacing: -.01em;
+  position: relative;
+  padding-top: var(--cna-s-5);
+}
+.page__hero--overlay .page__title::before{
+  content: "Cryptology & Algorithm Lab · Hanyang University";
+  display: block;
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  opacity: .85;
+}
+/* (#3) Yesteryear motto — soften the amber to a desaturated warm gray so it stops shouting */
+.cna-member-motto{
+  color: #8C6B3A;
+}
+
+/* (#4) Member open-state — drop amber alarm border, use stone */
+.cna-member[open]{
+  border-color: var(--cna-stone-line);
+}
+
+/* (#5) Animation consistency — remove hover lift on member <details> so click→expand feels coherent.
+   (Browsers can't smoothly animate <details> expand cross-browser; better to drop the conflicting lift.) */
+.cna-member:hover{
+  transform: none;
+  border-color: var(--cna-stone-line);
+}
+
+/* (#6) .cna-row no-meta variant — for award/press rows that don't carry an id column */
+.cna-row.cna-row--no-meta{
+  grid-template-columns: 1fr 200px;
+}
+@media (max-width: 760px){
+  .cna-row.cna-row--no-meta{ grid-template-columns: 1fr; }
+}
+
+/* (#7) chip-muted — outline-only chip for lower-tier awards (already declared earlier,
+   but tighten the look so it reads as a real "minor" tag) */
+.cna-chip-muted{
+  background: transparent;
+  color: var(--cna-faint);
+  border: 1px solid var(--cna-line);
+  font-weight: 600;
+  letter-spacing: .08em;
+}
+
+/* (#8) Publication aside slightly wider so "year · acc % · DOI" doesn't squeeze */
+.cna-row{
+  grid-template-columns: 56px 1fr 240px;
+}
+/* Projects override stays narrower thanks to its earlier rule; explicit re-declare for clarity */
+.cna-projects .cna-row{
+  grid-template-columns: 160px 1fr 180px;
+}
+@media (max-width: 760px){
+  .cna-row{ grid-template-columns: 1fr; }
+}
+
+/* (#9) Seminar TBA placeholders — tone down the .cna-card-meta when it carries only "TBA" */
+.cna-card-meta[data-tba],
+.cna-card-meta.cna-tba{
+  font-style: italic;
+  opacity: .55;
+  font-weight: 400;
+}
+
+/* (#12) Footer — replace minimal-mistakes default with a lab-identity block */
+.page__footer-identity{
+  text-align: center;
+  margin-bottom: var(--cna-s-3);
+}
+.page__footer-identity .cna-footer-lead{
+  font-size: var(--cna-fs-base);
+  color: var(--cna-ink);
+  line-height: 1.6;
+  margin-bottom: 4px;
+}
+.page__footer-identity .cna-footer-lead b{
+  color: var(--cna-ink);
+  font-weight: 700;
+}
+.page__footer-identity .cna-footer-meta{
+  font-size: var(--cna-fs-sm);
+  color: var(--cna-soft);
+}
+.page__footer-identity .cna-footer-meta a{
+  color: var(--cna-indigo);
+  text-decoration: none;
+}
+.page__footer-identity .cna-footer-meta a:hover{
+  text-decoration: underline;
 }
 
 </style>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -745,22 +745,23 @@ body{
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
   gap: var(--cna-s-5);
 }
-/* For an OPEN member card that's the only one in its grid (solo
-   section like Professor), split into a 2-column layout: summary on
-   the left, bio on the right — so the wider card breathes instead of
-   leaving its right half empty. round-6: raise breakpoint to 1024px
-   so the bio side gets genuine room; use minmax for graceful
-   collapse on borderline widths. */
+/* For an OPEN member card that's the only one in its grid AND has bio
+   content (only Prof qualifies after round-8), split into a 2-column
+   layout: summary on the left, bio on the right — so the wider card
+   breathes instead of leaving its right half empty.
+   round-8 fix: scope to :has(.cna-member-bio) so single-member
+   sections WITHOUT bio (Postdoc / PhD / Master) don't trigger a
+   useless 2-col split when clicked. */
 @media (min-width: 1024px){
-  .cna-member[open]:only-child{
+  .cna-member[open]:only-child:has(.cna-member-bio){
     display: grid;
     grid-template-columns: minmax(360px, 0.5fr) minmax(0, 1fr);
     gap: 0;
   }
-  .cna-member[open]:only-child > summary{
+  .cna-member[open]:only-child:has(.cna-member-bio) > summary{
     border-right: 1px solid var(--cna-rule);
   }
-  .cna-member[open]:only-child > .cna-member-bio{
+  .cna-member[open]:only-child:has(.cna-member-bio) > .cna-member-bio{
     border-top: none;
     padding: var(--cna-s-5);
   }
@@ -891,11 +892,8 @@ body{
   text-transform: uppercase;
   opacity: .85;
 }
-/* Suppress on homepage — there the title IS the lab identity, eyebrow would be redundant */
-.layout--splash[data-page-class="home"] .page__hero--overlay .page__title::before,
-body.page--home .page__hero--overlay .page__title::before{
-  content: none;
-}
+/* (round-8 reversion: keep the eyebrow on homepage too — user
+   liked having the lab full name + Hanyang University there.) */
 /* (#3) Yesteryear motto — soften the amber to a desaturated warm gray so it stops shouting */
 .cna-member-motto{
   color: #8C6B3A;

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -776,6 +776,30 @@ body{
   from{ opacity: 0; }
   to{   opacity: 1; }
 }
+
+/* round-8: non-Prof member cards have no bio. Clicking still triggers
+   <details> open — expand the card to span the full grid row so the
+   click feels meaningful (the "one-column effect" the user asked for). */
+.cna-member[open]:not(:only-child){
+  grid-column: 1 / -1;
+}
+/* When the spanned card has no bio, give the summary a touch more
+   horizontal breathing room so it doesn't look like a stretched
+   header-only block. */
+.cna-member[open]:not(:only-child) > summary{
+  padding: var(--cna-s-2) 0;
+}
+
+/* round-8: motto stays on one line whenever the card has full-row room
+   — either as the sole member of its roster (auto-fit single-col) or
+   after being clicked open (grid-column: 1 / -1). Otherwise wraps. */
+.cna-roster-grid > .cna-member:only-child .cna-member-motto,
+.cna-member[open] .cna-member-motto{
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
 .cna-member-card{
   padding: var(--cna-s-5);
   gap: var(--cna-s-4);

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -40,6 +40,12 @@
   --cna-stone-wash:    #EFEDE7;
   --cna-stone-line:    #C8C2B2;
 
+  /* round-7: separate seminar/lecture from conference paper.
+     Plum/violet — scholarly, distinct from indigo conference. */
+  --cna-plum:          #6B4D80;
+  --cna-plum-wash:     #EDE7F1;
+  --cna-plum-line:     #C8B8D2;
+
   /* surface + ink */
   --cna-ink:           #1F2227;
   --cna-soft:          #52575F;
@@ -85,6 +91,7 @@
 .cna-cat-award  { --cat: var(--cna-forest);  --cat-wash: var(--cna-forest-wash);  --cat-line: var(--cna-forest-line);  }
 .cna-cat-event  { --cat: var(--cna-amber);   --cat-wash: var(--cna-amber-wash);   --cat-line: var(--cna-amber-line);   }
 .cna-cat-people { --cat: var(--cna-stone);   --cat-wash: var(--cna-stone-wash);   --cat-line: var(--cna-stone-line);   }
+.cna-cat-seminar{ --cat: var(--cna-plum);    --cat-wash: var(--cna-plum-wash);    --cat-line: var(--cna-plum-line);    }
 
 /* ──────────────────────────────────────────────────────────
    2. SECTION
@@ -122,6 +129,7 @@
 .cna-section.cna-cat-award  .cna-section-head{ border-bottom-color: var(--cna-forest-line); }
 .cna-section.cna-cat-event  .cna-section-head{ border-bottom-color: var(--cna-amber-line); }
 .cna-section.cna-cat-people .cna-section-head{ border-bottom-color: var(--cna-stone-line); }
+.cna-section.cna-cat-seminar .cna-section-head{ border-bottom-color: var(--cna-plum-line); }
 
 /* ──────────────────────────────────────────────────────────
    3. CHIP
@@ -140,6 +148,7 @@
 .cna-chip-award  { background: var(--cna-forest-wash);  color: var(--cna-forest);  }
 .cna-chip-event  { background: var(--cna-amber-wash);   color: var(--cna-amber);   }
 .cna-chip-people { background: var(--cna-stone-wash);   color: var(--cna-stone);   }
+.cna-chip-seminar{ background: var(--cna-plum-wash);    color: var(--cna-plum);    }
 
 .cna-chip-muted{
   background: transparent; color: var(--cna-faint);
@@ -168,6 +177,7 @@
 .cna-card.cna-cat-award:hover  { border-color: var(--cna-forest-line);  }
 .cna-card.cna-cat-event:hover  { border-color: var(--cna-amber-line);   }
 .cna-card.cna-cat-people:hover { border-color: var(--cna-stone-line);   }
+.cna-card.cna-cat-seminar:hover{ border-color: var(--cna-plum-line);    }
 
 .cna-card-head{
   display: flex; align-items: baseline; justify-content: space-between;
@@ -426,6 +436,7 @@
 .cna-tally-pill.cna-tally-award  { color: var(--cna-forest);  border-color: var(--cna-forest-line);  }
 .cna-tally-pill.cna-tally-event  { color: var(--cna-amber);   border-color: var(--cna-amber-line);   }
 .cna-tally-pill.cna-tally-people { color: var(--cna-stone);   border-color: var(--cna-stone-line);   }
+.cna-tally-pill.cna-tally-seminar{ color: var(--cna-plum);    border-color: var(--cna-plum-line);    }
 
 /* ──────────────────────────────────────────────────────────
    9. PHOTO GRID (Gallery)

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -722,14 +722,16 @@ body{
   background: var(--cna-bg);
 }
 /* round-9 #2: highlighted current sub-page in News sidebar (and any
-   sidebar nav using the docs collection). */
+   sidebar nav using the docs collection). round-11: simplified —
+   text color + weight only, no rectangle bg / border accent. */
 .nav__list .nav__items a.active,
 .nav__list .nav__items a[aria-current="page"]{
   color: var(--cna-indigo);
   font-weight: 700;
-  background: var(--cna-indigo-wash);
-  border-left: 3px solid var(--cna-indigo);
-  padding-left: 8px;
+}
+.nav__list .nav__items a.active:hover,
+.nav__list .nav__items a[aria-current="page"]:hover{
+  background: transparent;
 }
 
 /* tighten splash layout body padding so cards sit closer to hero */

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,8 +13,18 @@
         </a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+            {%- assign is_active = false -%}
+            {%- assign link_url = link.url | replace: "https://Cryptology-Algorithm-Lab.github.io", "" -%}
+            {%- if link_url == "/" or link_url == "" -%}
+              {%- if page.url == "/" -%}{%- assign is_active = true -%}{%- endif -%}
+            {%- else -%}
+              {%- assign link_segments = link_url | split: "/" -%}
+              {%- assign link_root = link_segments[1] -%}
+              {%- assign match_path = "/" | append: link_root | append: "/" -%}
+              {%- if page.url contains match_path -%}{%- assign is_active = true -%}{%- endif -%}
+            {%- endif -%}
+            <li class="masthead__menu-item{% if is_active %} masthead__menu-item--active{% endif %}">
+              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}{% if is_active %} aria-current="page"{% endif %}>{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,20 +11,24 @@
           {{ site.masthead_title | default: site.title }}
           {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle }}</span>{% endif %}
         </a>
+        {%- comment -%} Compute the current page's first-path-segment once. {%- endcomment -%}
+        {%- if page.url == "/" or page.url == "" or page.url == "/index.html" -%}
+          {%- assign page_section = "_home" -%}
+        {%- else -%}
+          {%- assign page_segs = page.url | split: "/" -%}
+          {%- assign page_section = page_segs[1] -%}
+        {%- endif -%}
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
-            {%- assign is_active = false -%}
-            {%- assign link_url = link.url | replace: "https://Cryptology-Algorithm-Lab.github.io", "" -%}
-            {%- if link_url == "/" or link_url == "" -%}
-              {%- if page.url == "/" -%}{%- assign is_active = true -%}{%- endif -%}
+            {%- assign clean = link.url | replace: "https://Cryptology-Algorithm-Lab.github.io", "" -%}
+            {%- if clean == "" or clean == "/" -%}
+              {%- assign link_section = "_home" -%}
             {%- else -%}
-              {%- assign link_segments = link_url | split: "/" -%}
-              {%- assign link_root = link_segments[1] -%}
-              {%- assign match_path = "/" | append: link_root | append: "/" -%}
-              {%- if page.url contains match_path -%}{%- assign is_active = true -%}{%- endif -%}
+              {%- assign link_segs = clean | split: "/" -%}
+              {%- assign link_section = link_segs[1] -%}
             {%- endif -%}
-            <li class="masthead__menu-item{% if is_active %} masthead__menu-item--active{% endif %}">
-              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}{% if is_active %} aria-current="page"{% endif %}>{{ link.title }}</a>
+            <li class="masthead__menu-item{% if link_section == page_section %} masthead__menu-item--active{% endif %}">
+              <a href="{{ link.url | relative_url }}"{% if link.description %} title="{{ link.description }}"{% endif %}{% if link_section == page_section %} aria-current="page"{% endif %}>{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>

--- a/_includes/nav_list
+++ b/_includes/nav_list
@@ -6,9 +6,11 @@
   <label for="ac-toc">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle Menu" }}</label>
   <ul class="nav__items">
     {% for nav in navigation %}
+      {%- assign is_active_top = false -%}
+      {%- if nav.url and nav.url == page.url -%}{%- assign is_active_top = true -%}{%- endif -%}
       <li>
         {% if nav.url %}
-          <a href="{{ nav.url | relative_url }}"><span class="nav__sub-title">{{ nav.title }}</span></a>
+          <a href="{{ nav.url | relative_url }}"{% if is_active_top %} class="active" aria-current="page"{% endif %}><span class="nav__sub-title">{{ nav.title }}</span></a>
         {% else %}
           <span class="nav__sub-title">{{ nav.title }}</span>
         {% endif %}
@@ -16,7 +18,7 @@
         {% if nav.children != null %}
         <ul>
           {% for child in nav.children %}
-            <li><a href="{{ child.url | relative_url }}"{% if child.url == page.url %} class="active"{% endif %}>{{ child.title }}</a></li>
+            <li><a href="{{ child.url | relative_url }}"{% if child.url == page.url %} class="active" aria-current="page"{% endif %}>{{ child.title }}</a></li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}{% if page.url == '/' %} page--home{% endif %}">
     {% include_cached skip-links.html %}
     {% include_cached browser-upgrade.html %}
     {% include masthead.html %}{%- comment -%} round-5: use plain include (was include_cached) so page.url-based active nav state renders per-page {%- endcomment -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     {% include_cached skip-links.html %}
     {% include_cached browser-upgrade.html %}
-    {% include_cached masthead.html %}
+    {% include masthead.html %}{%- comment -%} round-5: use plain include (was include_cached) so page.url-based active nav state renders per-page {%- endcomment -%}
 
     <div class="initial-content">
       {{ content }}

--- a/_pages/Gallery.md
+++ b/_pages/Gallery.md
@@ -12,224 +12,345 @@ header:
 gallery:
   - url: /assets/Gallery/asiacrypt_hyeonbum.png
     image_path: /assets/Gallery/asiacrypt_hyeonbum.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "ASIACRYPT 2022 — Hyeonbum Lee presentation"
   - url: /assets/Gallery/asiacrypt_hyeonbum_1.png
     image_path: /assets/Gallery/asiacrypt_hyeonbum_1.png
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "ASIACRYPT 2022 — Hyeonbum Lee presentation"
 gallery1:
   - url: /assets/Gallery/grad_bs_bora.png
     image_path: /assets/Gallery/grad_bs_bora.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Bora Jeong graduation"
 gallery2:
   - url: /assets/Gallery/banner_cna.png
     image_path: /assets/Gallery/banner_cna.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "C&A Lab banner"
   - url: /assets/Gallery/cryptoanalysis_paik.jpg
     image_path: /assets/Gallery/cryptoanalysis_paik.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Cryptanalysis"
   - url: /assets/Gallery/h1.jpeg
     image_path: /assets/Gallery/h1.jpeg
-    alt: "placeholder image 3"
-    title: "Image 2 title caption" 
+    alt: "Achievement"
   - url: /assets/Gallery/h2.jpeg
     image_path: /assets/Gallery/h2.jpeg
-    alt: "placeholder image 4"
-    title: "Image 2 title caption"
+    alt: "Achievement"
 gallery3:
   - url: /assets/Gallery/teachersday23_1.png
     image_path: /assets/Gallery/teachersday23_1.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Teacher's Day 2023"
   - url: /assets/Gallery/teachersday23_2.png
     image_path: /assets/Gallery/teachersday23_2.png
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"    
+    alt: "Teacher's Day 2023"
 gallery4:
   - url: /assets/Gallery/23_10_1.jpg
     image_path: /assets/Gallery/23_10_1.jpg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Cryptographic Contests 2023"
   - url: /assets/Gallery/23_10_2.jpg
     image_path: /assets/Gallery/23_10_2.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Cryptographic Contests 2023"
 gallery4_1:
   - url: /assets/Gallery/23_10_3.jpg
     image_path: /assets/Gallery/23_10_3.jpg
-    alt: "placeholder image 3"
-    title: "Image 1 title caption"
+    alt: "Cryptographic Contests 2023"
   - url: /assets/Gallery/23_10_4.jpg
     image_path: /assets/Gallery/23_10_4.jpg
-    alt: "placeholder image 4"
-    title: "Image 2 title caption"
+    alt: "Cryptographic Contests 2023"
 gallery5:
   - url: /assets/Gallery/bmvc1.jpg
     image_path: /assets/Gallery/bmvc1.jpg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "BMVC 2023"
   - url: /assets/Gallery/bmvc2.jpg
     image_path: /assets/Gallery/bmvc2.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "BMVC 2023"
 gallery6:
   - url: /assets/Gallery/sp1.jpeg
     image_path: /assets/Gallery/sp1.jpeg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "IEEE S&P 2024"
   - url: /assets/Gallery/sp2.jpeg
     image_path: /assets/Gallery/sp2.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "IEEE S&P 2024"
 gallery7:
   - url: /assets/Gallery/hb_1.JPG
     image_path: /assets/Gallery/hb_1.JPG
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "ZKProof6 & ICBC 2024"
   - url: /assets/Gallery/hb_2.jpg
     image_path: /assets/Gallery/hb_2.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "ZKProof6 & ICBC 2024"
 gallery8:
-  - url: /assets/Gallery/
+  - url: /assets/Gallery/workshop'24.JPEG
     image_path: /assets/Gallery/workshop'24.JPEG
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
-  - url: /assets/Gallery/hb_2.jpg
+    alt: "MPC & SNARK Workshop 2024"
+  - url: /assets/Gallery/workshop'24_1.jpg
     image_path: /assets/Gallery/workshop'24_1.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "MPC & SNARK Workshop 2024"
 gallery9:
-  - url: /assets/Gallery/
+  - url: /assets/Gallery/cryptanalysis_2024.jpg
     image_path: /assets/Gallery/cryptanalysis_2024.jpg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
-  - url: /assets/Gallery/hb_2.jpg
+    alt: "Cryptanalysis Contest 2024"
+  - url: /assets/Gallery/cryptanalysis_2024_1.jpg
     image_path: /assets/Gallery/cryptanalysis_2024_1.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Cryptanalysis Contest 2024"
 gallery10:
   - url: /assets/Gallery/nation24_1.png
     image_path: /assets/Gallery/nation24_1.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Cryptographic Technology Contest 2024"
   - url: /assets/Gallery/nation24_2.jpeg
     image_path: /assets/Gallery/nation24_2.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Cryptographic Technology Contest 2024"
 gallery11:
   - url: /assets/Gallery/hb_cel1.jpg
     image_path: /assets/Gallery/hb_cel1.jpg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Hyeonbum Lee graduation"
   - url: /assets/Gallery/hb_cel2.jpg
     image_path: /assets/Gallery/hb_cel2.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Hyeonbum Lee graduation"
 gallery12:
   - url: /assets/Gallery/kccv25_1.jpg
     image_path: /assets/Gallery/kccv25_1.jpg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "KCCV 2025"
   - url: /assets/Gallery/kccv25_2.jpg
     image_path: /assets/Gallery/kccv25_2.jpg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "KCCV 2025"
   - url: /assets/Gallery/kccv25_3.jpg
     image_path: /assets/Gallery/kccv25_3.jpg
-    alt: "placeholder image 3"
-    title: "Image 3 title caption"
+    alt: "KCCV 2025"
   - url: /assets/Gallery/kccv25_4.jpg
     image_path: /assets/Gallery/kccv25_4.jpg
-    alt: "placeholder image 4"
-    title: "Image 4 title caption"
+    alt: "KCCV 2025"
 gallery13:
   - url: /assets/Gallery/contest25.jpeg
     image_path: /assets/Gallery/contest25.jpeg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Cryptographic Technology Contest 2025"
   - url: /assets/Gallery/contest25_2.jpeg
     image_path: /assets/Gallery/contest25_2.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Cryptographic Technology Contest 2025"
 gallery14:
   - url: /assets/Gallery/mathday1_sh.jpeg
     image_path: /assets/Gallery/mathday1_sh.jpeg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Day of Mathematics 2025"
   - url: /assets/Gallery/mathday2_sh.jpeg
     image_path: /assets/Gallery/mathday2_sh.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Day of Mathematics 2025"
 gallery15:
   - url: /assets/Gallery/SP_grad1.jpeg
     image_path: /assets/Gallery/SP_grad1.jpeg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Sunpill Kim graduation"
   - url: /assets/Gallery/SP_grad2.jpeg
     image_path: /assets/Gallery/SP_grad2.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Sunpill Kim graduation"
 gallery16:
   - url: /assets/Gallery/math1.jpeg
     image_path: /assets/Gallery/math1.jpeg
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "MATH Workshop"
   - url: /assets/Gallery/math2.jpeg
     image_path: /assets/Gallery/math2.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "MATH Workshop"
 gallery17:
   - url: /assets/Gallery/best_paper_2603.png
     image_path: /assets/Gallery/best_paper_2603.png
-    alt: "placeholder image 1"
-    title: "Image 1 title caption"
+    alt: "Outstanding Paper, Hanyang University"
   - url: /assets/Gallery/best_paper_2603_1.jpeg
     image_path: /assets/Gallery/best_paper_2603_1.jpeg
-    alt: "placeholder image 2"
-    title: "Image 2 title caption"
+    alt: "Outstanding Paper, Hanyang University"
 ---
+
 # Gallery
-{% include gallery id="gallery17" caption="**Congrats on Selection as Outstanding Paper, Hanyang University**" %}
 
-{% include gallery id="gallery16" caption="**MATH: Make AI Trust Higher” Workshop at Hanyang University – exploring the intersection of AI, mathematics, and cryptography.**" %}
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2026</h3>
+    <span class="cna-year-count">3 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-{% include gallery id="gallery15" caption="**Celebrating the graduation of Sunpill Kim – wishing him continued success ahead.**" %}
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>Outstanding Paper, Hanyang University</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery17" %}
+  </section>
 
-{% include gallery id="gallery14" caption="Seunhun Paik's invited talk at The Day of Mathmatics 2025, Hanyang University" %}
+  <section class="cna-section cna-cat-event" markdown="0">
+    <header class="cna-section-head">
+      <h3>MATH: Make AI Trust Higher — Workshop at Hanyang University</h3>
+      <span class="cna-chip cna-chip-event">Workshop</span>
+    </header>
+    {% include gallery id="gallery16" %}
+  </section>
 
-{% include gallery id="gallery13" caption="Congrats on several awards in the National Cryptographic Technology Contest 2025." %}
+  <section class="cna-section cna-cat-people" markdown="0">
+    <header class="cna-section-head">
+      <h3>Celebrating Sunpill Kim’s graduation</h3>
+      <span class="cna-chip cna-chip-people">Member</span>
+    </header>
+    {% include gallery id="gallery15" %}
+  </section>
 
-{% include gallery id="gallery12" layout="half" caption="**Our lab at KCCV 2025 – a great time of academic exchange, with a birthday celebration for Changjin Kim.**" %}
+  </div>
+</details>
 
-{% include gallery id="gallery11" caption="**Celebrating the graduation of Hyeonbum Lee – wishing him continued success ahead.**" %}
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2025</h3>
+    <span class="cna-year-count">4 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-{% include gallery id="gallery10" caption="**Congrats on several awards in the National Cryptographic Technology Contest 2024.**" %}
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>Seunghun Paik’s invited talk — Day of Mathematics 2025</h3>
+      <span class="cna-chip cna-chip-talk">Invited Talk</span>
+    </header>
+    {% include gallery id="gallery14" %}
+  </section>
 
-{% include gallery id="gallery9" caption="**Congrats the award in Cryptanalysis Contest.**" %}
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>National Cryptographic Technology Contest 2025</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery13" %}
+  </section>
 
-{% include gallery id="gallery8" caption="**MPC & SNARK Workshop 2024**" %}
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>KCCV 2025 — and a birthday celebration for Changjin Kim</h3>
+      <span class="cna-chip cna-chip-talk">Conference</span>
+    </header>
+    {% include gallery id="gallery12" layout="half" %}
+  </section>
 
-{% include gallery id="gallery7" caption="**Hyeonbum Lee's presentation at the ZKProof6 & ICBC 2024**" %}
+  <section class="cna-section cna-cat-people" markdown="0">
+    <header class="cna-section-head">
+      <h3>Celebrating Hyeonbum Lee’s graduation</h3>
+      <span class="cna-chip cna-chip-people">Member</span>
+    </header>
+    {% include gallery id="gallery11" %}
+  </section>
 
-{% include gallery id="gallery6" caption="**Sunpill Kim's presentation at the IEEE S&P 2024**" %}
+  </div>
+</details>
 
-{% include gallery id="gallery5" caption="**Seunghun Paik's presentation at the BMVC 2023**" %}
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2024</h3>
+    <span class="cna-year-count">5 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-{% include gallery id="gallery4_1"%}
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>National Cryptographic Technology Contest 2024</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery10" %}
+  </section>
 
-{% include gallery id="gallery4" caption="**Congrats on sevaral awards in the National Cryptographic Technology Contest and Cryptanalysis Contest 2023.**" %}
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>Cryptanalysis Contest 2024</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery9" %}
+  </section>
 
-{% include gallery id="gallery3" caption="**Thank you, professor, for celebrating Teacher's Day.**" %}
+  <section class="cna-section cna-cat-event" markdown="0">
+    <header class="cna-section-head">
+      <h3>MPC &amp; SNARK Workshop 2024</h3>
+      <span class="cna-chip cna-chip-event">Workshop</span>
+    </header>
+    {% include gallery id="gallery8" %}
+  </section>
 
-{% include gallery id="gallery" caption="**Hyeonbum Lee's presentation at the ASIACRYPT 2022**" %}
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>Hyeonbum Lee — ZKProof6 &amp; IEEE ICBC 2024</h3>
+      <span class="cna-chip cna-chip-talk">Conference</span>
+    </header>
+    {% include gallery id="gallery7" %}
+  </section>
 
-{% include gallery id="gallery2" layout="half" caption="**Congratulations on the researchers' achievements**" %}
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>Sunpill Kim — IEEE S&amp;P 2024</h3>
+      <span class="cna-chip cna-chip-talk">Conference</span>
+    </header>
+    {% include gallery id="gallery6" %}
+  </section>
 
-{% include gallery id="gallery1" caption="**Congratulations on Bora Jeong's graduation! Welcome to C&A Lab.**" %}
+  </div>
+</details>
 
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2023</h3>
+    <span class="cna-year-count">3 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>Seunghun Paik — BMVC 2023</h3>
+      <span class="cna-chip cna-chip-talk">Conference</span>
+    </header>
+    {% include gallery id="gallery5" %}
+  </section>
+
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>National Cryptographic Technology &amp; Cryptanalysis Contests 2023</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery4" %}
+    {% include gallery id="gallery4_1" %}
+  </section>
+
+  <section class="cna-section cna-cat-people" markdown="0">
+    <header class="cna-section-head">
+      <h3>Teacher’s Day with the lab</h3>
+      <span class="cna-chip cna-chip-people">Lab Life</span>
+    </header>
+    {% include gallery id="gallery3" %}
+  </section>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022 &amp; earlier</h3>
+    <span class="cna-year-count">3 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <section class="cna-section cna-cat-talk" markdown="0">
+    <header class="cna-section-head">
+      <h3>Hyeonbum Lee — ASIACRYPT 2022</h3>
+      <span class="cna-chip cna-chip-talk">Conference</span>
+    </header>
+    {% include gallery id="gallery" %}
+  </section>
+
+  <section class="cna-section cna-cat-award" markdown="0">
+    <header class="cna-section-head">
+      <h3>Researcher achievements</h3>
+      <span class="cna-chip cna-chip-award">Award</span>
+    </header>
+    {% include gallery id="gallery2" layout="half" %}
+  </section>
+
+  <section class="cna-section cna-cat-people" markdown="0">
+    <header class="cna-section-head">
+      <h3>Welcome — Bora Jeong</h3>
+      <span class="cna-chip cna-chip-people">Member</span>
+    </header>
+    {% include gallery id="gallery1" %}
+  </section>
+
+  </div>
+</details>

--- a/_pages/Gallery.md
+++ b/_pages/Gallery.md
@@ -196,10 +196,10 @@ gallery17:
   </summary>
   <div class="cna-year-body">
 
-  <section class="cna-section cna-cat-talk" markdown="0">
+  <section class="cna-section cna-cat-seminar" markdown="0">
     <header class="cna-section-head">
       <h3>Seunghun Paik’s invited talk — Day of Mathematics 2025</h3>
-      <span class="cna-chip cna-chip-talk">Invited Talk</span>
+      <span class="cna-chip cna-chip-seminar">Invited Talk</span>
     </header>
     {% include gallery id="gallery14" %}
   </section>

--- a/_pages/Gallery.md
+++ b/_pages/Gallery.md
@@ -8,7 +8,7 @@ sidebar:
 permalink: /News/Gallery/
 header:
   overlay_image: /assets/images/korea.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 gallery:
   - url: /assets/Gallery/asiacrypt_hyeonbum.png
     image_path: /assets/Gallery/asiacrypt_hyeonbum.png

--- a/_pages/Gallery.md
+++ b/_pages/Gallery.md
@@ -153,8 +153,6 @@ gallery17:
     alt: "Outstanding Paper, Hanyang University"
 ---
 
-# Gallery
-
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026</h3>

--- a/_pages/Interest.md
+++ b/_pages/Interest.md
@@ -10,95 +10,78 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
-<details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Verifiable Computation
-    </summary>
-    <br>
-    <p>In page of "Verifiable computing" of wikipedia, Verifiable computing (or verified computation or verified computing) enables a computer to offload the computation of some function, to other perhaps untrusted clients, while maintaining verifiable results. The other clients evaluate the function and return the result with a proof that the computation of the function was carried out correctly. The introduction of this notion came as a result of the increasingly common phenomenon of "outsourcing" computation to untrusted users in projects such as <A href="https://en.wikipedia.org/wiki/SETI@home">SETI@home</A> and also to the growing desire of weak clients to outsource computational tasks to a more powerful computation service like in cloud computing.</p>
-    <details>
-        <summary>
-            What is the NIZK?
-        </summary>
-        Interactive Proofs (IPs) and Arguments
-        <ul type="square">
-            <li><p>Prover <i>P</i> and Verfier <i>V</i><br>
-                1. <i>P</i> solves a problem on a given input.<br>
-                2. Tells <i>V</i> the answer.<br>
-                3. Then <i>P</i> proves to <i>V</i> that the answer is correct.</p>
-                <ul type="none">
-                    <li><p>Requirements:<br>
-                        <u>Completeness</u>: If the answer is true, the honest <i>V</i> will be convinced of this fact by an untrusted <i>P</i> (honest <i>P</i> in ZKP).<br>
-                        <u>Soundness</u>: If the answer is false, no <i>P</i> (no cheating <i>P</i> in ZKP) can convince the honest <i>V</i> that it is true, except with some small probability.</p>
-                    </li>
-                </ul>
-            </li>
-            <li><p>Difference of IPs and Arguments<br>
-                The difference is that the prover is restricted to be a polynomial-time algorithm for an interactive arguement, whereas no such restrictions on the prover apply for an interactive proof.</p>
-            </li>
-        </ul>
-        Zero-Knowledge Proof (ZKP) and Non-Interactive Proofs
-        <ul type="square">
-            <li><p>Zero-Knowledge Proof<br>
-                ZKP is one of the IPs and is a method by which <i>P</i> can prove to <i>V</i> that they know a secret, without conveying any information apart from the fact that they know the secret.<br></p>
-                <ul type="none">
-                    <li><p>More requirement for ZKP:<br>
-                        <u>Zero-knowledge</u>: If the answer is true, no <i>V</i> learns anything other than the fact that the answer is true.</p>
-                    </li>
-                </ul>
-            </li>
-            <li><p>Non-Interactive Proofs<br>
-                Non-Interactive Proofs require no interaction between the <i>P</i> and <i>V</i>.</p>
-            </li>
-        </ul>
-        Therefore, Non-interactive zero-knowledge proofs (also known as NIZK, zk-SNARK) are zero-knowledge proofs that require no interaction between the <i>P</i> and <i>V</i>.
+<section class="cna-section cna-cat-talk" markdown="0">
+  <header class="cna-section-head">
+    <h2>Verifiable Computation</h2>
+    <span class="cna-chip cna-chip-talk">Research Area</span>
+  </header>
+
+  <div class="cna-prose cna-cat-talk">
+    <p>In the Wikipedia entry for “Verifiable computing,” verifiable computing (or verified computation / verified computing) enables a computer to offload the computation of some function to other, perhaps untrusted, clients while maintaining verifiable results. The other clients evaluate the function and return the result with a proof that the computation was carried out correctly.</p>
+    <p>The introduction of this notion came as a result of the increasingly common phenomenon of outsourcing computation to untrusted users in projects such as <a href="https://en.wikipedia.org/wiki/SETI@home">SETI@home</a>, and of the growing desire of weak clients to outsource computational tasks to a more powerful computation service such as cloud computing.</p>
+
+    <details class="cna-learn-more">
+      <summary>What is NIZK?</summary>
+      <p><b>Interactive Proofs (IPs) and Arguments.</b> A Prover <i>P</i> and a Verifier <i>V</i> interact as follows: <i>P</i> solves a problem on a given input, tells <i>V</i> the answer, and then proves to <i>V</i> that the answer is correct.</p>
+      <p>The proof system must satisfy two properties:</p>
+      <ul>
+        <li><u>Completeness</u>: If the answer is true, the honest <i>V</i> will be convinced of this fact by an untrusted <i>P</i> (honest <i>P</i> in ZKP).</li>
+        <li><u>Soundness</u>: If the answer is false, no <i>P</i> (no cheating <i>P</i> in ZKP) can convince the honest <i>V</i> that it is true, except with some small probability.</li>
+      </ul>
+      <p>The difference between IPs and arguments is that the prover is restricted to be a polynomial-time algorithm for an interactive argument, whereas no such restriction applies for an interactive proof.</p>
+      <p><b>Zero-Knowledge Proof (ZKP) and Non-Interactive Proofs.</b> ZKP is a method by which <i>P</i> can prove to <i>V</i> that they know a secret, without conveying any information apart from the fact that they know the secret. The additional requirement is:</p>
+      <ul>
+        <li><u>Zero-knowledge</u>: If the answer is true, no <i>V</i> learns anything other than the fact that the answer is true.</li>
+      </ul>
+      <p>Non-interactive proofs require no interaction between <i>P</i> and <i>V</i>. Therefore, non-interactive zero-knowledge proofs (also known as NIZK, zk-SNARK) are zero-knowledge proofs that require no interaction between the prover and the verifier.</p>
     </details>
-    <details>
-        <summary>
-            What is the PCD?
-        </summary>
-        <br>
-        <ul type="square">
-          <li><A href="https://projects.csail.mit.edu/pcd/">PCD(Proof-Carrying-Data)</A><br></li></ul>
-        <ul type="none">
-        <p>Proof-carrying data, PCD, is a cryptographic primitive applied to distributed computing, in DAG(directed acyclic graph), where multiple subjects without mutual trust generally participate.<br>In distributed computing, when a large operation is performed in multiple steps, the subject, in each node in distributed computing, of a step in the operation sends message including result of the operation to the subject who performs the next step of operation.<br>A proof is attached to the message, and the proof attests about the correctness of the result of the operation performed at both of  present node and previous one.</p> 
-        PCD can usually be built by Recursive proof composition of cryptographic proof systems such as SNARK. In the recursive proof composition, in order to generate the proof as mentioned above, it is required that the verifier algorithm, of the component proof system, be embedded in the arithmetic circuit proved by the system.<br>
-However, depending on the time complexity of the operation of the verifier algorithm, the size of the proof grows larger as the operation proceeds, so verifying the proof requires more computation than performing the operation directly, so the verification becomes meaningless.<br> 
-So, research on the types of proof systems that can be used as a component of the recursive proof composition and the method of the recursive proof composition is ongoing.<br></ul>    
-</details>
-<br>
-<details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Secure Machine Learning (Cryptographic Approach)
-    </summary>
-    <br>
-    <p>With the successful development of deep learning, biometric authentication technology based on convolutional neural networks has remarkably advanced.<br>
-    <A href="https://arxiv.org/abs/1801.07698/">ArcFace</A> based on <A href="https://arxiv.org/abs/1512.03385">Residual neural network</A>, one of the convolutional neural networks, is the recent state-of-the-art face recognition system and outputs highly discriminative feature templates for face authentication using additive angular margin loss.<br>
-    However, when face recognition system become able to compress well into feature template from face image more and more, leakage of face templates is more serious threat to user privacy. For example, face images can be reconstructed from face feature templates using <A href="https://arxiv.org/abs/1703.00832">neighborly de-convolutional neural network</A> and this is serious threat to user privacy.</p>
-    Therefore we develop a modular architecture <A href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">Ironmask</A> for protecting face feature templates that can be combined with any face recognition system that using angular distance metric such as <A href="https://arxiv.org/abs/1704.08063">SphereFace</A>, <A href="https://arxiv.org/abs/1801.09414">CosFace</A>, <A href="https://arxiv.org/abs/1801.07698">ArcFace</A>.
-    <br>
-    <img src="{{ site.url }}{{ site.baseurl }}/assets/images/CVPR.jpg" alt="">
-</details>
-<br>
-<details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Blockchain
-    </summary>
-    <br>
-    <p>A number of third-party services require personal data, and users need to delegate personal data to service providers who may modify and share the data with other service providers. <br>For example, patients must share their medical records with hospitals, which can be updated and shared among different departments/hospitals and even insurance companies; internet users have to consent to personal data collection to use various services (e.g., location-based services, social media services), and personal data may be updated and shared for use in other inter-connected services.<br>
-      Additionally, IoT devices in smart home systems exchange data with smart home hubs (e.g., Google Home, Amazon Alexa, Apple HomeKit). Even though such modification and sharing occur with the users’ consent, more transparency for the user is desired during the whole procedure.
-    </p>
-    <img src="{{ site.url }}{{ site.baseurl }}/assets/images/blockchain.png" alt="">
-    <p>Personal data are shared by their owners with service providers for different needs, and these data can be modified and further shared among other service providers. For transparency and accountability of such delegated data, a personal data provenance monitoring system recording how owners’ data are propagated and modified is necessary.<br>However, achieving this involves significant challenges, due to the decentralized relationships of different service providers.<br>Therefore, we propose using blockchain to track the provenance of owners’ data. <br>While, for privacy reasons, what service providers can upload to the blockchain is limited to some sharing records that do not reveal data contents, and blockchain peers must validate them without actual data contents. <br>So, we propose a new extended vector commitment (EVC) scheme for monitoring personal data provenance in third-party services.
-    </p>   
-</details>
-<br>
-<details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Functional Encryption
-    </summary>
-    <br>
-    <p>Functional Encryption (FE) is a new public key encryption system that extends the existing public key encryption concept more flexibly. It is a public key encryption that allows the decryption condition of a cipher text to be specified as an arbitrary function. At this time, Functional Encryption guarantees complete privacy by not exposing unnecessary information related to the cipher text to not only system outsiders but also system insiders.<br>
-    The purpose of ongoing research (Research on Functional Encryption Technique Design, Analysis and Implementation Technology, supported by IITP) is to obtain the important source technologies of FE that is considered to be next-generation public-key encryption and to study the extended technologies of FE for cloud computing. In addition, this research studies techniques of other cryptographic primetives like Lattices.</p>
-    
-</details>
+
+    <details class="cna-learn-more">
+      <summary>What is PCD?</summary>
+      <p><a href="https://projects.csail.mit.edu/pcd/">Proof-Carrying Data (PCD)</a> is a cryptographic primitive applied to distributed computing in a DAG (directed acyclic graph) setting, where multiple subjects without mutual trust generally participate.</p>
+      <p>In distributed computing, when a large operation is performed in multiple steps, the subject at each node sends a message including the result of its step to the subject who performs the next step. A proof is attached to the message, attesting to the correctness of the result at both the present node and the previous one.</p>
+      <p>PCD can usually be built by recursive proof composition of cryptographic proof systems such as SNARK. In recursive proof composition, in order to generate the proof as mentioned above, the verifier algorithm of the component proof system must be embedded in the arithmetic circuit proved by the system. However, depending on the time complexity of the verifier algorithm, the size of the proof grows larger as the operation proceeds, so verifying the proof can require more computation than performing the operation directly, making verification meaningless. Research on the types of proof systems that can be used as components of recursive proof composition, and on the method of recursive proof composition itself, is ongoing.</p>
+    </details>
+  </div>
+</section>
+
+<section class="cna-section cna-cat-paper" markdown="0">
+  <header class="cna-section-head">
+    <h2>Secure Machine Learning (Cryptographic Approach)</h2>
+    <span class="cna-chip cna-chip-paper">Research Area</span>
+  </header>
+
+  <div class="cna-prose cna-cat-paper">
+    <p>With the successful development of deep learning, biometric authentication technology based on convolutional neural networks has remarkably advanced. <a href="https://arxiv.org/abs/1801.07698/">ArcFace</a>, based on a <a href="https://arxiv.org/abs/1512.03385">Residual neural network</a>, is the recent state-of-the-art face recognition system and outputs highly discriminative feature templates for face authentication using additive angular margin loss.</p>
+    <p>However, when a face recognition system becomes able to compress face images into feature templates more and more compactly, the leakage of face templates becomes a more serious threat to user privacy. For example, face images can be reconstructed from face feature templates using <a href="https://arxiv.org/abs/1703.00832">neighborly de-convolutional neural networks</a>, posing a serious threat to user privacy.</p>
+    <p>To address this, we developed a modular architecture, <a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask</a>, for protecting face feature templates that can be combined with any face recognition system using an angular distance metric, such as <a href="https://arxiv.org/abs/1704.08063">SphereFace</a>, <a href="https://arxiv.org/abs/1801.09414">CosFace</a>, and <a href="https://arxiv.org/abs/1801.07698">ArcFace</a>.</p>
+    <img src="{{ site.url }}{{ site.baseurl }}/assets/images/CVPR.jpg" alt="IronMask architecture overview from CVPR 2021">
+  </div>
+</section>
+
+<section class="cna-section cna-cat-event" markdown="0">
+  <header class="cna-section-head">
+    <h2>Blockchain</h2>
+    <span class="cna-chip cna-chip-event">Research Area</span>
+  </header>
+
+  <div class="cna-prose cna-cat-event">
+    <p>A number of third-party services require personal data, and users need to delegate personal data to service providers who may modify and share the data with other service providers. For example, patients must share their medical records with hospitals, which can be updated and shared among different departments, hospitals, and even insurance companies. Internet users have to consent to personal data collection to use various services (e.g., location-based services, social media services), and personal data may be updated and shared for use across inter-connected services.</p>
+    <p>Additionally, IoT devices in smart home systems exchange data with smart home hubs (e.g., Google Home, Amazon Alexa, Apple HomeKit). Even though such modification and sharing occur with the users’ consent, more transparency for the user is desired throughout the entire procedure.</p>
+    <img src="{{ site.url }}{{ site.baseurl }}/assets/images/blockchain.png" alt="Blockchain-based data provenance diagram">
+    <p>Personal data are shared by their owners with service providers for different needs, and these data can be modified and further shared among other service providers. For transparency and accountability of such delegated data, a personal data provenance monitoring system that records how owners’ data are propagated and modified is necessary. However, achieving this involves significant challenges, due to the decentralized relationships between different service providers.</p>
+    <p>Therefore, we propose using blockchain to track the provenance of owners’ data. For privacy reasons, what service providers can upload to the blockchain is limited to sharing records that do not reveal the data contents, and blockchain peers must validate these records without seeing the actual data. We propose a new extended vector commitment (EVC) scheme for monitoring personal data provenance in third-party services.</p>
+  </div>
+</section>
+
+<section class="cna-section cna-cat-award" markdown="0">
+  <header class="cna-section-head">
+    <h2>Functional Encryption</h2>
+    <span class="cna-chip cna-chip-award">Research Area</span>
+  </header>
+
+  <div class="cna-prose cna-cat-award">
+    <p>Functional Encryption (FE) is a new public key encryption system that extends the existing public-key encryption concept more flexibly. It is a public-key encryption that allows the decryption condition of a ciphertext to be specified as an arbitrary function. Functional Encryption guarantees complete privacy by not exposing unnecessary information related to the ciphertext to system outsiders or even system insiders.</p>
+    <p>The purpose of our ongoing research — <i>Research on Functional Encryption Technique Design, Analysis and Implementation Technology</i>, supported by IITP — is to obtain the important source technologies of FE, considered to be next-generation public-key encryption, and to study extended techniques of FE for cloud computing. We also study other cryptographic primitives such as lattices.</p>
+  </div>
+</section>

--- a/_pages/Interest.md
+++ b/_pages/Interest.md
@@ -10,13 +10,12 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-<section class="cna-section cna-cat-talk" markdown="0">
+<section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
     <h2>Verifiable Computation</h2>
-    <span class="cna-chip cna-chip-talk">Research Area</span>
   </header>
 
-  <div class="cna-prose cna-cat-talk">
+  <div class="cna-prose cna-cat-people">
     <p>In the Wikipedia entry for “Verifiable computing,” verifiable computing (or verified computation / verified computing) enables a computer to offload the computation of some function to other, perhaps untrusted, clients while maintaining verifiable results. The other clients evaluate the function and return the result with a proof that the computation was carried out correctly.</p>
     <p>The introduction of this notion came as a result of the increasingly common phenomenon of outsourcing computation to untrusted users in projects such as <a href="https://en.wikipedia.org/wiki/SETI@home">SETI@home</a>, and of the growing desire of weak clients to outsource computational tasks to a more powerful computation service such as cloud computing.</p>
 
@@ -45,13 +44,12 @@ header:
   </div>
 </section>
 
-<section class="cna-section cna-cat-paper" markdown="0">
+<section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
     <h2>Secure Machine Learning (Cryptographic Approach)</h2>
-    <span class="cna-chip cna-chip-paper">Research Area</span>
   </header>
 
-  <div class="cna-prose cna-cat-paper">
+  <div class="cna-prose cna-cat-people">
     <p>With the successful development of deep learning, biometric authentication technology based on convolutional neural networks has remarkably advanced. <a href="https://arxiv.org/abs/1801.07698/">ArcFace</a>, based on a <a href="https://arxiv.org/abs/1512.03385">Residual neural network</a>, is the recent state-of-the-art face recognition system and outputs highly discriminative feature templates for face authentication using additive angular margin loss.</p>
     <p>However, when a face recognition system becomes able to compress face images into feature templates more and more compactly, the leakage of face templates becomes a more serious threat to user privacy. For example, face images can be reconstructed from face feature templates using <a href="https://arxiv.org/abs/1703.00832">neighborly de-convolutional neural networks</a>, posing a serious threat to user privacy.</p>
     <p>To address this, we developed a modular architecture, <a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask</a>, for protecting face feature templates that can be combined with any face recognition system using an angular distance metric, such as <a href="https://arxiv.org/abs/1704.08063">SphereFace</a>, <a href="https://arxiv.org/abs/1801.09414">CosFace</a>, and <a href="https://arxiv.org/abs/1801.07698">ArcFace</a>.</p>
@@ -59,13 +57,12 @@ header:
   </div>
 </section>
 
-<section class="cna-section cna-cat-event" markdown="0">
+<section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
     <h2>Blockchain</h2>
-    <span class="cna-chip cna-chip-event">Research Area</span>
   </header>
 
-  <div class="cna-prose cna-cat-event">
+  <div class="cna-prose cna-cat-people">
     <p>A number of third-party services require personal data, and users need to delegate personal data to service providers who may modify and share the data with other service providers. For example, patients must share their medical records with hospitals, which can be updated and shared among different departments, hospitals, and even insurance companies. Internet users have to consent to personal data collection to use various services (e.g., location-based services, social media services), and personal data may be updated and shared for use across inter-connected services.</p>
     <p>Additionally, IoT devices in smart home systems exchange data with smart home hubs (e.g., Google Home, Amazon Alexa, Apple HomeKit). Even though such modification and sharing occur with the users’ consent, more transparency for the user is desired throughout the entire procedure.</p>
     <img src="{{ site.url }}{{ site.baseurl }}/assets/images/blockchain.png" alt="Blockchain-based data provenance diagram">
@@ -74,13 +71,12 @@ header:
   </div>
 </section>
 
-<section class="cna-section cna-cat-award" markdown="0">
+<section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
     <h2>Functional Encryption</h2>
-    <span class="cna-chip cna-chip-award">Research Area</span>
   </header>
 
-  <div class="cna-prose cna-cat-award">
+  <div class="cna-prose cna-cat-people">
     <p>Functional Encryption (FE) is a new public key encryption system that extends the existing public-key encryption concept more flexibly. It is a public-key encryption that allows the decryption condition of a ciphertext to be specified as an arbitrary function. Functional Encryption guarantees complete privacy by not exposing unnecessary information related to the ciphertext to system outsiders or even system insiders.</p>
     <p>The purpose of our ongoing research — <i>Research on Functional Encryption Technique Design, Analysis and Implementation Technology</i>, supported by IITP — is to obtain the important source technologies of FE, considered to be next-generation public-key encryption, and to study extended techniques of FE for cloud computing. We also study other cryptographic primitives such as lattices.</p>
   </div>

--- a/_pages/Interest.md
+++ b/_pages/Interest.md
@@ -7,7 +7,7 @@ permalink: /Interest/
 excerpt: 'Interesting Cryptography!'
 header:
   overlay_image: /assets/images/seoul.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 <section class="cna-section cna-cat-talk" markdown="0">

--- a/_pages/Interest.md
+++ b/_pages/Interest.md
@@ -10,9 +10,17 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
+<nav class="cna-page-toc" aria-label="Research areas" markdown="0">
+  <span class="cna-page-toc-label">Topics</span>
+  <a class="cna-page-toc-item" href="#verifiable-computation">Verifiable Computation</a>
+  <a class="cna-page-toc-item" href="#secure-ml">Secure ML</a>
+  <a class="cna-page-toc-item" href="#blockchain">Blockchain</a>
+  <a class="cna-page-toc-item" href="#functional-encryption">Functional Encryption</a>
+</nav>
+
 <section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
-    <h2>Verifiable Computation</h2>
+    <h2 id="verifiable-computation">Verifiable Computation</h2>
   </header>
 
   <div class="cna-prose cna-cat-people">
@@ -46,7 +54,7 @@ header:
 
 <section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
-    <h2>Secure Machine Learning (Cryptographic Approach)</h2>
+    <h2 id="secure-ml">Secure Machine Learning (Cryptographic Approach)</h2>
   </header>
 
   <div class="cna-prose cna-cat-people">
@@ -59,7 +67,7 @@ header:
 
 <section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
-    <h2>Blockchain</h2>
+    <h2 id="blockchain">Blockchain</h2>
   </header>
 
   <div class="cna-prose cna-cat-people">
@@ -73,7 +81,7 @@ header:
 
 <section class="cna-section cna-cat-people" markdown="0">
   <header class="cna-section-head">
-    <h2>Functional Encryption</h2>
+    <h2 id="functional-encryption">Functional Encryption</h2>
   </header>
 
   <div class="cna-prose cna-cat-people">

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -35,7 +35,7 @@ header:
           <div class="cna-member-meta">
             <a class="cna-member-name" href="https://sites.google.com/site/jhsbhs/">Jae Hong Seo<span class="cna-ext">↗</span></a>
             <span class="cna-member-role">Professor</span>
-            <span class="cna-member-motto">Stay hungry. Stay foolish.</span>
+            <span class="cna-member-motto">Stay hungry.<br>Stay foolish.</span>
             <span class="cna-member-interests">Cryptography · Computational Number Theory · Zero-Knowledge Proofs · Biometric Authentication</span>
           </div>
         </div>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -62,23 +62,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Selected Publications</h4>
-        <ul>
-          <li>Seunghun Paik, Dongsoo Kim, Chanwoo Hwang, Sunpill Kim and Jae Hong Seo, <i>Towards Certifiably Robust Face Recognition</i>, ECCV 2024 (acc. 27.9%)</li>
-          <li>Sunpill Kim et al., <i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i>, IEEE S&amp;P 2024 (<a href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</a>, acc. 14.9%)</li>
-          <li>Sunpill Kim and Yong Kiam Tan, <i>Formalization of the Schwartz-Zippel Lemma</i>, Archive of Formal Proofs, Apr 2023.</li>
-          <li>Seunghun Paik, Sunpill Kim, and Jae Hong Seo, <i>Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes</i>, BMVC 2023.</li>
-          <li>Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, <i>Attack on Secure Triplet Loss</i>, IEEE Access.</li>
-          <li>Sunpill Kim et al., <i>IronMask: Modular Architecture for Protecting Deep Face Template</i>, CVPR 2021, pp. 16125–16134 (acc. 23.4%).</li>
-        </ul>
-        <h4>Awards</h4>
-        <ul>
-          <li>A*STAR Research Attachment Programme (ARAP), Jan 2023 – Jan 2024. A*STAR, Singapore (S$38,400).</li>
-          <li>Special Prize, National Cryptographic Technology Contest, Sep 2022. National Intelligence Service, Republic of Korea — “Deep Face Template Protection in the Wild” ($500).</li>
-          <li>Excellence Prize, Academic Seminar, Nov 2019. College of Natural Science, Hanyang University — “Security of Biometric Authentication” ($300).</li>
-        </ul>
-      </div>
     </details>
 
   </div>
@@ -103,10 +86,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Research Interests</h4>
-        <p>AI Security, Computer Vision</p>
-      </div>
     </details>
 
   </div>
@@ -131,12 +110,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Awards</h4>
-        <ul>
-          <li>2021 Academic Seminar, College of Natural Science, Hanyang University — Participation Prize.</li>
-        </ul>
-      </div>
     </details>
 
     <details class="cna-member">
@@ -151,10 +124,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Research Interests</h4>
-        <p>Cryptography</p>
-      </div>
     </details>
 
     <details class="cna-member">
@@ -169,18 +138,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Selected Publications</h4>
-        <ul>
-          <li>Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, <i>Analysis on Secure Triplet Loss</i>, IEEE Access, 2022.</li>
-          <li>Seunghun Paik, Sunpill Kim, and Jae Hong Seo, <i>Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes</i>, BMVC 2023.</li>
-        </ul>
-        <h4>Awards</h4>
-        <ul>
-          <li>2022 Cryptanalysis Contest, Military Cryptography Research Center — Excellence Award.</li>
-          <li>2019 Academic Seminar, College of Natural Science, Hanyang University — Excellence Prize.</li>
-        </ul>
-      </div>
     </details>
 
     <details class="cna-member">
@@ -195,13 +152,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Awards</h4>
-        <ul>
-          <li>2022 Cryptanalysis Contest, Military Cryptography Research Center — Excellence Award.</li>
-          <li>2022 Academic Seminar, College of Natural Science, Hanyang University — Excellence Prize.</li>
-        </ul>
-      </div>
     </details>
 
   </div>
@@ -226,12 +176,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Awards</h4>
-        <ul>
-          <li>2023 Academic Seminar, College of Natural Science, Hanyang University — Encouragement Prize.</li>
-        </ul>
-      </div>
     </details>
 
   </div>
@@ -256,10 +200,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Research Interests</h4>
-        <p>AI Security, Computer Vision</p>
-      </div>
     </details>
 
     <details class="cna-member">
@@ -274,10 +214,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Research Interests</h4>
-        <p>Cryptography</p>
-      </div>
     </details>
 
     <details class="cna-member">
@@ -292,10 +228,6 @@ header:
           </div>
         </div>
       </summary>
-      <div class="cna-member-bio">
-        <h4>Research Interests</h4>
-        <p>Cryptography, Deep Learning Algorithms</p>
-      </div>
     </details>
 
   </div>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -18,11 +18,7 @@ header:
   <a class="cna-page-toc-item" href="#integrated-course">Integrated</a>
   <a class="cna-page-toc-item" href="#masters-student">Master's</a>
   <a class="cna-page-toc-item" href="#undergrad">Undergrad</a>
-  <span class="cna-page-toc-label">Alumni</span>
-  <a class="cna-page-toc-item" href="#alumni-postdoc">Postdoc</a>
-  <a class="cna-page-toc-item" href="#alumni-phd">Ph.D</a>
-  <a class="cna-page-toc-item" href="#alumni-master">Master</a>
-  <a class="cna-page-toc-item" href="#alumni-undergrad">Undergrad</a>
+  <a class="cna-page-toc-item" href="#alumni-postdoc">Alumni</a>
 </nav>
 
 <section class="cna-roster cna-section" markdown="0">

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -10,9 +10,24 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
+<nav class="cna-page-toc" aria-label="Members navigation" markdown="0">
+  <span class="cna-page-toc-label">Members</span>
+  <a class="cna-page-toc-item" href="#professor">Professor</a>
+  <a class="cna-page-toc-item" href="#postdoc">Postdoc</a>
+  <a class="cna-page-toc-item" href="#phd-student">Ph.D</a>
+  <a class="cna-page-toc-item" href="#integrated-course">Integrated</a>
+  <a class="cna-page-toc-item" href="#masters-student">Master's</a>
+  <a class="cna-page-toc-item" href="#undergrad">Undergrad</a>
+  <span class="cna-page-toc-label">Alumni</span>
+  <a class="cna-page-toc-item" href="#alumni-postdoc">Postdoc</a>
+  <a class="cna-page-toc-item" href="#alumni-phd">Ph.D</a>
+  <a class="cna-page-toc-item" href="#alumni-master">Master</a>
+  <a class="cna-page-toc-item" href="#alumni-undergrad">Undergrad</a>
+</nav>
+
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Professor</h2>
+    <h2 id="professor">Professor</h2>
     <span class="cna-section-count">1</span>
   </header>
   <div class="cna-roster-grid">
@@ -45,7 +60,7 @@ header:
 
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Postdoc</h2>
+    <h2 id="postdoc">Postdoc</h2>
     <span class="cna-section-count">1</span>
   </header>
   <div class="cna-roster-grid">
@@ -69,7 +84,7 @@ header:
 
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Ph.D Student</h2>
+    <h2 id="phd-student">Ph.D Student</h2>
     <span class="cna-section-count">1</span>
   </header>
   <div class="cna-roster-grid">
@@ -93,7 +108,7 @@ header:
 
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Ms &amp; Ph.D Integrated Course</h2>
+    <h2 id="integrated-course">Ms &amp; Ph.D Integrated Course</h2>
     <span class="cna-section-count">4</span>
   </header>
   <div class="cna-roster-grid">
@@ -159,7 +174,7 @@ header:
 
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Master's Student</h2>
+    <h2 id="masters-student">Master's Student</h2>
     <span class="cna-section-count">1</span>
   </header>
   <div class="cna-roster-grid">
@@ -183,7 +198,7 @@ header:
 
 <section class="cna-roster cna-section" markdown="0">
   <header class="cna-section-head">
-    <h2>Undergraduate Student</h2>
+    <h2 id="undergrad">Undergraduate Student</h2>
     <span class="cna-section-count">3</span>
   </header>
   <div class="cna-roster-grid">
@@ -235,7 +250,7 @@ header:
 
 <details class="cna-year" markdown="0">
   <summary>
-    <h3>Alumni — PostDoc</h3>
+    <h3 id="alumni-postdoc">Alumni — PostDoc</h3>
     <span class="cna-year-count">1</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
@@ -252,7 +267,7 @@ header:
 
 <details class="cna-year" markdown="0">
   <summary>
-    <h3>Alumni — Ph.D</h3>
+    <h3 id="alumni-phd">Alumni — Ph.D</h3>
     <span class="cna-year-count">2</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
@@ -274,7 +289,7 @@ header:
 
 <details class="cna-year" markdown="0">
   <summary>
-    <h3>Alumni — Master</h3>
+    <h3 id="alumni-master">Alumni — Master</h3>
     <span class="cna-year-count">7</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
@@ -293,7 +308,7 @@ header:
 
 <details class="cna-year" markdown="0">
   <summary>
-    <h3>Alumni — Undergraduate</h3>
+    <h3 id="alumni-undergrad">Alumni — Undergraduate</h3>
     <span class="cna-year-count">19</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -300,79 +300,91 @@ header:
   </div>
 </section>
 
-<section class="cna-roster cna-section" markdown="0">
-  <header class="cna-section-head">
-    <h2>Alumni — PostDoc</h2>
-    <span class="cna-section-count">1</span>
-  </header>
-  <div class="cna-alumni-grid">
-    <div class="cna-alum">
-      <span class="cna-alum-name">Heewon Chung</span>
-      <span class="cna-alum-affil">— Assistant Professor, Jeonbuk National University</span>
-      <span class="cna-alum-when">Left Dec 2021</span>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>Alumni — PostDoc</h3>
+    <span class="cna-year-count">1</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-alumni-grid">
+      <div class="cna-alum">
+        <span class="cna-alum-name">Heewon Chung</span>
+        <span class="cna-alum-affil">— Assistant Professor, Jeonbuk National University</span>
+        <span class="cna-alum-when">Left Dec 2021</span>
+      </div>
     </div>
   </div>
-</section>
+</details>
 
-<section class="cna-roster cna-section" markdown="0">
-  <header class="cna-section-head">
-    <h2>Alumni — Ph.D</h2>
-    <span class="cna-section-count">2</span>
-  </header>
-  <div class="cna-alumni-grid">
-    <div class="cna-alum">
-      <span class="cna-alum-name">Hyeonbum Lee</span>
-      <span class="cna-alum-affil">— Postdoc, Seoul National University</span>
-      <span class="cna-alum-when">Graduated Aug 2025</span>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>Alumni — Ph.D</h3>
+    <span class="cna-year-count">2</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-alumni-grid">
+      <div class="cna-alum">
+        <span class="cna-alum-name">Hyeonbum Lee</span>
+        <span class="cna-alum-affil">— Postdoc, Seoul National University</span>
+        <span class="cna-alum-when">Graduated Aug 2025</span>
+      </div>
+      <div class="cna-alum">
+        <span class="cna-alum-name">Sunpill Kim</span>
+        <span class="cna-alum-affil">— Postdoc, Hanyang University</span>
+        <span class="cna-alum-when">Graduated Feb 2026</span>
+      </div>
     </div>
-    <div class="cna-alum">
-      <span class="cna-alum-name">Sunpill Kim</span>
-      <span class="cna-alum-affil">— Postdoc, Hanyang University</span>
-      <span class="cna-alum-when">Graduated Feb 2026</span>
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>Alumni — Master</h3>
+    <span class="cna-year-count">7</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-alumni-grid">
+      <div class="cna-alum"><span class="cna-alum-name">Hwamin Yoo</span><span class="cna-alum-when">Feb 2017</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Changjin Kim</span><span class="cna-alum-when">Feb 2017</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Gyumin Lim</span><span class="cna-alum-affil">— KAIST Cyber Security Research Center</span><span class="cna-alum-when">Feb 2021</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Chanyang Ju</span><span class="cna-alum-when">Feb 2023</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Gwangwoon Lee</span><span class="cna-alum-affil">— ArtygenSpace</span><span class="cna-alum-when">Aug 2024</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Kyuhwan Lee</span><span class="cna-alum-affil">— Korean National Police Agency</span><span class="cna-alum-when">Aug 2024</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span><span class="cna-alum-when">Aug 2024</span></div>
     </div>
   </div>
-</section>
+</details>
 
-<section class="cna-roster cna-section" markdown="0">
-  <header class="cna-section-head">
-    <h2>Alumni — Master</h2>
-    <span class="cna-section-count">7</span>
-  </header>
-  <div class="cna-alumni-grid">
-    <div class="cna-alum"><span class="cna-alum-name">Hwamin Yoo</span><span class="cna-alum-when">Feb 2017</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Changjin Kim</span><span class="cna-alum-when">Feb 2017</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Gyumin Lim</span><span class="cna-alum-affil">— KAIST Cyber Security Research Center</span><span class="cna-alum-when">Feb 2021</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Chanyang Ju</span><span class="cna-alum-when">Feb 2023</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Gwangwoon Lee</span><span class="cna-alum-affil">— ArtygenSpace</span><span class="cna-alum-when">Aug 2024</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Kyuhwan Lee</span><span class="cna-alum-affil">— Korean National Police Agency</span><span class="cna-alum-when">Aug 2024</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span><span class="cna-alum-when">Aug 2024</span></div>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>Alumni — Undergraduate</h3>
+    <span class="cna-year-count">19</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-alumni-grid">
+      <div class="cna-alum"><span class="cna-alum-name">Sunpill Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Dongyoung Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Jaeyong Ahn</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Jungmin Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Suryun Ji</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Eunwoo Im</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Taesam Kim</span><span class="cna-alum-affil">— Hyundai Mobis</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Chanwoo Hwang</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Dongsoo Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Hyunjung Son</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Seongae Baek</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Sangyoon Shin</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Yunjeong Heo</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Seunghun Paik</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Minsu Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Hyeonkyu Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Yunki Kim</span></div>
+      <div class="cna-alum"><span class="cna-alum-name">Heejin Kim</span></div>
+    </div>
   </div>
-</section>
-
-<section class="cna-roster cna-section" markdown="0">
-  <header class="cna-section-head">
-    <h2>Alumni — Undergraduate</h2>
-    <span class="cna-section-count">19</span>
-  </header>
-  <div class="cna-alumni-grid">
-    <div class="cna-alum"><span class="cna-alum-name">Sunpill Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Dongyoung Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Jaeyong Ahn</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Jungmin Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Suryun Ji</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Eunwoo Im</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Taesam Kim</span><span class="cna-alum-affil">— Hyundai Mobis</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Chanwoo Hwang</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Dongsoo Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Hyunjung Son</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Seongae Baek</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Sangyoon Shin</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Yunjeong Heo</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Seunghun Paik</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Minsu Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Hyeonkyu Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Yunki Kim</span></div>
-    <div class="cna-alum"><span class="cna-alum-name">Heejin Kim</span></div>
-  </div>
-</section>
+</details>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -152,7 +152,8 @@ header:
         </div>
       </summary>
       <div class="cna-member-bio">
-        <p><em>“Study without desire spoils the memory, and it retains nothing that it takes in.”</em> — Leonardo da Vinci</p>
+        <h4>Research Interests</h4>
+        <p>Cryptography</p>
       </div>
     </details>
 
@@ -169,7 +170,6 @@ header:
         </div>
       </summary>
       <div class="cna-member-bio">
-        <p>“Be professional; be sceptical on your work.” — Terrence Tao</p>
         <h4>Selected Publications</h4>
         <ul>
           <li>Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, <i>Analysis on Secure Triplet Loss</i>, IEEE Access, 2022.</li>
@@ -227,7 +227,6 @@ header:
         </div>
       </summary>
       <div class="cna-member-bio">
-        <p>“The foolish man seeks happiness in the distance, the wise man grows it under his feet.” — James Oppenheim</p>
         <h4>Awards</h4>
         <ul>
           <li>2023 Academic Seminar, College of Natural Science, Hanyang University — Encouragement Prize.</li>
@@ -276,7 +275,8 @@ header:
         </div>
       </summary>
       <div class="cna-member-bio">
-        <p>“If you do not change direction, you may end up where you were heading.”</p>
+        <h4>Research Interests</h4>
+        <p>Cryptography</p>
       </div>
     </details>
 
@@ -293,7 +293,8 @@ header:
         </div>
       </summary>
       <div class="cna-member-bio">
-        <p>“One day or day one, you decide.”</p>
+        <h4>Research Interests</h4>
+        <p>Cryptography, Deep Learning Algorithms</p>
       </div>
     </details>
 

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -10,455 +10,487 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Cookie&family=Dancing+Script&family=Yesteryear&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Yesteryear&display=swap" rel="stylesheet">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Professor
-    </summary>
-    <ul type="square">
-        <li><p style="text-align:left;"><A href="https://sites.google.com/site/jhsbhs/"><b sytle="font-size:120%;">Jae Hong Seo</b></A>
-            <br>
-            <img src="{{ site.url }}{{ site.baseurl }}/assets/images/jaehong.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-               <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Stay hungry. Stay foolish.</span>
-            </p>
-            <u>Education</u>
-            <br>
-            Seoul National University
-            <br>
-            <i><p style="text-align:left;">Ph.D in Mathematics<span style="float:right;">Feb 2011</span></p></i>                
-            Korea University
-            <br>
-            <i><p style="text-align:left;">BS in Mathematics<span style="float:right;">Feb 2004</span></p></i>
-            <u>Research Interests</u>
-            <br>
-            Cryptography, Computational Number Theory, Information Security (Recently, very interested in crypto primitives for secure blockchains and/or deep learning such as zero-knowledge proofs and bio authentication)            
-        </li>
-    </ul>
-</details>
+<style type="text/css">
+.cna-roster{ margin:0; }
+.cna-roster-head{
+  display:flex; align-items:baseline; gap:12px;
+  margin:28px 0 14px; padding-bottom:6px;
+  border-bottom:1px solid #f0ecdf;
+}
+.cna-roster-head h2{
+  margin:0; padding:0; border:none;
+  font-size:1.25rem; font-weight:700; color:#1f2227;
+}
+.cna-roster-count{
+  font-size:12px; color:#52575f; font-weight:600;
+  padding:2px 10px; background:#eeece7; border-radius:999px;
+}
 
-<br>
+.cna-roster-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(290px, 1fr));
+  gap:16px;
+}
 
-<details>
-  <summary style="font-size:1.2rem; font-weight:bold;">
-      Postdoc
-  </summary>
-  <ul type = "square">
-    <br>
-    <li><p style="text-align:left;"><A href="https://sunpill.github.io"><b sytle="font-size:120%;">Sunpill Kim</b></A>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Sunpill1.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Freedom is not free.</span>
-        </p>
-        <u>Research Interests</u>
-        <br>  
-        AI Security, Deep Learning, and Cryptography
-        <br>
-        <br>  
-        <details>
-          <summary>
-            Publication
-          </summary>
-          <ul>
-            <li>
-              Seunghun Paik, Dongsoo Kim, Chanwoo Hwang, Sunpill Kim and Jae Hong Seo, Towards Certifiably Robust Face Recognition, The 18th European Conference on Computer Vision ECCV 2024</b> 2024, (TBA) (<b>Top-tier conference in computer vision</b>, acceptance rate: 27.9%)
-            </li>
-            <li>
-              Sunpill Kim, Yong Kiam Tan, Bora Jeong, Soumik Mondal, Khin Mi Mi Aung, and Jae Hong Seo, Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems, IEEE Symposium on Security and Privacy (S&P) 2024, (<A href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</A>) (<b>Top-tier conference in cybersecurity</b>, acceptance rate: 14.9%)
-            </li>
-            <li>
-              Sunpill Kim and Yong Kiam Tan, Formalization of the Schwartz-Zippel Lemma, Archive of Formal Proofs, April 2023.
-            </li>
-            <li>
-              Seunghun Paik, Sunpill Kim, and Jae Hong Seo ,Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes, 34rd British Machine Vision Conference (BMVC) 2023
-            </li>
-            <li>
-              Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, Attack on Secure Triplet Loss, IEEE Access.
-            </li>
-            <li>
-              Sunpill Kim, Yunseong Jeong, Jinsu Kim, Jungkon Kim, Hyung Tae Lee, and Jae Hong Seo, IronMask: Modular Architecture for Protecting Deep Face Template, In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), pages 16125-16134, 2021.(acceptance rate 23.4%)
-            </li>
-          </ul>  
-        </details> 
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              A*STAR Research Attachment Programme (ARAP) Jan 2023 - Jan 2024 Agency for Science, Technology and Research (A*STAR), Singapore S$38400
-            </li>
-            <li>
-              Special Prize, National Cryptographic Technology Contest. Sep 2022 National Intelligence Service, Republic of Korea “Deep Face Template Protection in the Wild” $500
-            </li>  
-            <li>
-              Excellence Prize, Academic Seminar. Nov 2019 College of Natural Science, Hanyang University “Security of Biometric Authentication” $300
-            </li>  
-          </ul>          
-        </details>  
-    </li>  
-  </ul>
-</details>
+.cna-member{
+  background:#fff; border:1px solid #e6e2d8; border-radius:14px;
+  overflow:hidden;
+  box-shadow:0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
+  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+.cna-member:hover{
+  border-color:#c8c2b2;
+  transform:translateY(-2px);
+  box-shadow:0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
+}
+.cna-member[open]{
+  border-color:#b8740a;
+}
+.cna-member > summary{
+  cursor:pointer; user-select:none; list-style:none;
+  outline:none;
+}
+.cna-member > summary::-webkit-details-marker{ display:none; }
 
-<br>
+.cna-member-card{
+  display:flex; gap:14px; padding:16px 16px;
+  align-items:flex-start;
+}
+.cna-member-photo{
+  width:88px; height:88px; border-radius:12px;
+  object-fit:cover; flex:0 0 88px;
+  background:#f4f0e2;
+}
+.cna-member-meta{ min-width:0; display:flex; flex-direction:column; gap:2px; flex:1; }
+.cna-member-name{
+  font-size:16px; font-weight:600; color:#1f2227; text-decoration:none;
+  line-height:1.2;
+}
+.cna-member-name:hover{ text-decoration:underline; }
+.cna-member-name .cna-ext{ font-size:11px; opacity:.5; margin-left:3px; }
+.cna-member-role{
+  font-size:10.5px; color:#8a909a; letter-spacing:.08em;
+  text-transform:uppercase; font-weight:700;
+  margin-top:2px;
+}
+.cna-member-motto{
+  font-family:'Yesteryear', cursive;
+  font-size:18px; color:#b8740a;
+  line-height:1.15; margin-top:6px;
+}
+.cna-member-interests{
+  font-size:12.5px; color:#52575f; margin-top:6px; line-height:1.45;
+}
 
-<details>
-  <summary style="font-size:1.2rem; font-weight:bold;">
-      Ph.D student
-  </summary>
-  <ul type = "square">
-    <br>
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Changjin Kim</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/changjinkim.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Everything finds its place.</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-          AI Security, Computer Vision
-      </li>
-  </ul>  
-</details>
+.cna-member-bio{
+  padding:0 18px 16px;
+  border-top:1px solid #f0ecdf;
+  font-size:13.5px; line-height:1.55; color:#1f2227;
+}
+.cna-member-bio h4{
+  font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+  color:#8a909a; font-weight:700; margin:14px 0 6px;
+  border:none; padding:0;
+}
+.cna-member-bio ul{ padding-left:1.1em; margin:0; }
+.cna-member-bio li{ margin-bottom:4px; }
+.cna-member-bio .cna-edu{ width:100%; border-collapse:collapse; font-size:13.5px; }
+.cna-member-bio .cna-edu td{ padding:3px 0; border:none; vertical-align:top; }
+.cna-member-bio .cna-edu td:nth-child(1){ font-weight:500; }
+.cna-member-bio .cna-edu td:nth-child(2){ color:#52575f; font-style:italic; padding:0 12px; }
+.cna-member-bio .cna-edu td:nth-child(3){ color:#8a909a; font-size:12.5px; text-align:right; white-space:nowrap; }
 
-<br>
+/* Alumni — denser, no photo */
+.cna-alumni-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(240px, 1fr));
+  gap:0 24px;
+  margin-top:8px;
+}
+.cna-alum{
+  font-size:13.5px; color:#1f2227;
+  padding:10px 0;
+  border-bottom:1px solid #f4f0e2;
+}
+.cna-alum-name{ font-weight:600; }
+.cna-alum-affil{ color:#52575f; font-size:12.5px; }
+.cna-alum-when{ display:block; color:#8a909a; font-size:11.5px; margin-top:2px; letter-spacing:.04em; }
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Ms & Ph.D Integrated Course student
-    </summary>
-    <ul type="square">        
-        <br> 
-<!--     <br>
-        <li><p style="text-align:left;"><A href="https://hyeonbumlee.github.io"><b sytle="font-size:120%;">Hyeonbum Lee</b></A>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Hyeonbum.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >What doesn't kill me makes me stronger</span>
-        </p>
-        <u>Research Interests</u>
-        <br>
-        Cryptography(Zero-Knowledge Proofs)
-        </li>
-        <br>
-        <details>
-          <summary>
-            Publication
-          </summary>
-          <ul>
-            <li>
-              Hyeonbum Lee, Jae Hong Seo, "TENET : Sublogarithmic Proof, Sublinear Verifier Inner Product Argument without a Trusted Setup Accepted in IWSEC" 2023
-            </li>  
-            <li>
-              Sungwook Kim, Hyeonbum Lee, Jae Hong Seo, [alphabetical order] Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier Accepted in Asiacrypt 2022   
-            </li>
-            <li>
-              Chanyang Ju, Hyeonbum Lee, Heewon Chung, Jae Hong Seo, and Sungwook Kim, Efficient Sum-Check Protocol for Convolution IEEE Access, vol. 9, pp. 164047-164059, 2021, doi:10.1109/ACCESS.2021.3133442.
-            </li>
-            <li>
-              Chanyang Ju, Hyeonbum Lee, Heewon Chung, and Jae Hong Seo, Analysis of Zero-Knowledge Protocols for Verifiable Computation and Its Applications Journal of The Korea Institute of Information Security & Cryptology VOL.31, NO.4, Aug. 2020
-            </li>
-          </ul>  
-        </details> 
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              Grand Prize, National Cryptographic Technology Contest. Oct 2022 Korea Cryptography Forum 
-            </li>
-            <li>
-              Special Prize, National Cryptographic Technology Contest. Oct 2021 Korea Cryptography Forum
-            </li> 
-          </ul>  
-        </details>      -->
-      <br>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Chanwoo Hwang</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Chanwoo.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >To doubt is safer than to be secure.</span>
-        </p>       
-        <u>Research Interests</u>
-        <br>
-        AI Security, Deep Learning Algorithm, Computer Vision
-        <br>
-        <br>  
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              2021 Academic Seminar Hosted by College of Natural Science, Hanyang University Participation Prize
-            </li>
-          </ul>  
-        </details>  
-    </li>
-    <br>  
-    <!-- <li><p style="text-align:left;"><b sytle="font-size:120%;">Dongsoo Kim</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Dongsu.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Kites rise highest against the wind - not with it. -Winston Churchill-</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        Deep Learning Algorithm, Computer Vision
-        <br>
-        <br>  
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              2021 Academic Seminar Hosted by College of Natural Science, Hanyang University Participation Prize
-            </li>
-          </ul>  
-        </details>  
-    </li>
-    <br>   -->
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Hyunjung Son</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/hyunjung.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Study without desire spoils the memory, and it retains nothing that it takes in. -Leonardo da Vinci-</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        Cryptography          
-    </li>
-    <br>  
-    <li><p style="text-align:left;"><A href="https://sites.google.com/view/seunghunpaik/home?authuser=0"><b sytle="font-size:120%;">Seunghun Paik</b></A>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Seunghun.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Be professional; be sceptical on your work. -Terrence Tao-</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        Privacy Preserving Machine Learning
-        <br>  
-        <br>
-        <details>
-          <summary>
-            Publication
-          </summary>
-          <ul>
-            <li>
-              Analysis on Secure Triplet Loss Bora Jeong, Sunpill Kim, Seunghun Paik and Jae Hong Seo IEEE Access, 2022
-            </li>
-            <li>
-              Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes Seunghun Paik, Sunpill Kim and Jae Hong Seo Manuscript, Under Review
-            </li>
-          </ul>  
-        </details> 
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              2022 Cryptanalysis Contest Hosted by Millitary Cryptography Research Center Excellence Award
-            </li>
-            <li>
-              2019 Academic Seminar Hosted by College of Natural Science, Hanyang University Excellence Prize
-            </li>
-          </ul>  
-        </details>  
-      </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Minsu Kim</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/minsu.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >Better than yesterday</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        BTP(Biometric Template Protection)
-        <br>
-        <br>
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>
-            <li>
-              2022 Cryptanalysis Contest Hosted by Millitary Cryptography Research Center Excellence Award
-            </li>
-            <li>
-              2022 Academic Seminar Hosted by College of Natural Science, Hanyang University Excellence Prize
-            </li>
-          </ul>  
-        </details>  
-    </li>
-    </ul>      
-</details>
+@media (max-width:760px){
+  .cna-roster-grid{ grid-template-columns:1fr; }
+  .cna-alumni-grid{ grid-template-columns:1fr; }
+  .cna-member-card{ flex-direction:column; }
+  .cna-member-photo{ width:96px; height:96px; flex:0 0 96px; }
+}
+</style>
 
-<br>
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Professor</h2>
+    <span class="cna-roster-count">1</span>
+  </div>
+  <div class="cna-roster-grid">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Master's student
-    </summary>
-    <ul type="square">
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Yunki Kim</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/yunki.jpg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >The foolish man seeks happiness in the distance, the wise man grows It under his feet. -James Oppenheim-</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        Cryptography
-        <br>
-        <br>
-        <details>
-          <summary>
-            Awards
-          </summary>
-          <ul>            
-            <li>
-              2023 Academic Seminar Hosted by College of Natural Science, Hanyang University Encouragement Prize
-            </li>
-          </ul>  
-        </details>  
-    </li>      
-    </ul>
-</details>
+    <details class="cna-member" open>
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/jaehong.jpg" alt="Jae Hong Seo" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <a class="cna-member-name" href="https://sites.google.com/site/jhsbhs/">Jae Hong Seo<span class="cna-ext">↗</span></a>
+            <span class="cna-member-role">Professor</span>
+            <span class="cna-member-motto">Stay hungry. Stay foolish.</span>
+            <span class="cna-member-interests">Cryptography · Computational Number Theory · Zero-Knowledge Proofs · Biometric Authentication</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Education</h4>
+        <table class="cna-edu">
+          <tr><td>Seoul National University</td><td>Ph.D in Mathematics</td><td>Feb 2011</td></tr>
+          <tr><td>Korea University</td><td>BS in Mathematics</td><td>Feb 2004</td></tr>
+        </table>
+        <h4>Research Interests</h4>
+        <p>Cryptography, Computational Number Theory, Information Security (Recently, very interested in crypto primitives for secure blockchains and/or deep learning such as zero-knowledge proofs and bio authentication).</p>
+      </div>
+    </details>
 
-<br>
+  </div>
+</section>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Undergraduate student
-    </summary>
-    <ul type="square">
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Insoo Kim</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/insookim.jpeg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >No pain, No gain.</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-        AI security, Computer Vision
-        <br>
-    </li>
-    <br>  
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Hyeonmin Jang</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/hyeonminjang.jpeg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >If you do not change direction, you may end up where you were heading.</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-          Cryptography
-        <br>
-    </li>
-    <br>
-    <li><p style="text-align:left;"><b sytle="font-size:120%;">Ingeun Yun</b>
-        <br>
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/images/ingeunyun.jpeg" alt="" height="160" width="120" style="vertical-align:middle; margin-right: 75px;">
-          <span style="margin-top:20px; font-size:30px; font-family:Yesteryear" >One day or day one, you decide.</span>
-        </p>        
-        <u>Research Interests</u>
-        <br>
-          Cryptography , Deep Learning Algorithms 
-        <br>
-    </li>
-    </ul>
-</details>
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Postdoc</h2>
+    <span class="cna-roster-count">1</span>
+  </div>
+  <div class="cna-roster-grid">
 
-<br>
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Sunpill1.jpg" alt="Sunpill Kim" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <a class="cna-member-name" href="https://sunpill.github.io">Sunpill Kim<span class="cna-ext">↗</span></a>
+            <span class="cna-member-role">Postdoc</span>
+            <span class="cna-member-motto">Freedom is not free.</span>
+            <span class="cna-member-interests">AI Security · Deep Learning · Cryptography</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Selected Publications</h4>
+        <ul>
+          <li>Seunghun Paik, Dongsoo Kim, Chanwoo Hwang, Sunpill Kim and Jae Hong Seo, <i>Towards Certifiably Robust Face Recognition</i>, ECCV 2024 (acc. 27.9%)</li>
+          <li>Sunpill Kim et al., <i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i>, IEEE S&amp;P 2024 (<a href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</a>, acc. 14.9%)</li>
+          <li>Sunpill Kim and Yong Kiam Tan, <i>Formalization of the Schwartz-Zippel Lemma</i>, Archive of Formal Proofs, Apr 2023.</li>
+          <li>Seunghun Paik, Sunpill Kim, and Jae Hong Seo, <i>Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes</i>, BMVC 2023.</li>
+          <li>Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, <i>Attack on Secure Triplet Loss</i>, IEEE Access.</li>
+          <li>Sunpill Kim et al., <i>IronMask: Modular Architecture for Protecting Deep Face Template</i>, CVPR 2021, pp. 16125–16134 (acc. 23.4%).</li>
+        </ul>
+        <h4>Awards</h4>
+        <ul>
+          <li>A*STAR Research Attachment Programme (ARAP), Jan 2023 – Jan 2024. A*STAR, Singapore (S$38,400).</li>
+          <li>Special Prize, National Cryptographic Technology Contest, Sep 2022. National Intelligence Service, Republic of Korea — “Deep Face Template Protection in the Wild” ($500).</li>
+          <li>Excellence Prize, Academic Seminar, Nov 2019. College of Natural Science, Hanyang University — “Security of Biometric Authentication” ($300).</li>
+        </ul>
+      </div>
+    </details>
 
-<details>  
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Staff
-    </summary>
-</details>
+  </div>
+</section>
 
-<br>
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Ph.D Student</h2>
+    <span class="cna-roster-count">1</span>
+  </div>
+  <div class="cna-roster-grid">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Alumni (PostDoc)
-    </summary>
-    <ul type="square">
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Heewon Chung (Assistant Professor, Jeonbuk National University)</b><span style="float:right;"> <i>Dec 2021</i></span></p>
-    </li>
-    </ul>
-</details>
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/changjinkim.jpg" alt="Changjin Kim" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Changjin Kim</span>
+            <span class="cna-member-role">Ph.D Student</span>
+            <span class="cna-member-motto">Everything finds its place.</span>
+            <span class="cna-member-interests">AI Security · Computer Vision</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Research Interests</h4>
+        <p>AI Security, Computer Vision</p>
+      </div>
+    </details>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Alumni (Ph.D)
-    </summary>
-    <ul type="square">
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Hyeonbum Lee (Postdoc, Seoul National University)</b><span style="float:right;"> <i>Aug 2025</i></span></p>
-      </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Sunpill Kim (Postdoc, Hanyang University)</b><span style="float:right;"> <i>Feb 2026</i></span></p>
-      </li>
-     </ul> 
-</details>
+  </div>
+</section>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Alumni (Master)
-    </summary>
-    <ul type="square">
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Hwamin Yoo</b><span style="float:right;"> <i>Feb 2017</i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Changjin Kim</b><span style="float:right;"> <i>Feb 2017</i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Gyumin Lim (KAIST Cyber Security Research Center)</b><span style="float:right;"> <i>Feb 2021</i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Chanyang Ju</b><span style="float:right;"> <i>Feb 2023</i></span></p>
-    </li>  
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Gwangwoon Lee (ArtygenSpace)</b><span style="float:right;"><i>Aug 2024</i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Kyuhwan Lee (Korean National Police Agency)</b><span style="float:right;"><i>Aug 2024</i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Bora Jeong</b><span style="float:right;"><i>Aug 2024</i></span></p>
-    </li>
-    </ul>
-</details>
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Ms &amp; Ph.D Integrated Course</h2>
+    <span class="cna-roster-count">4</span>
+  </div>
+  <div class="cna-roster-grid">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        Alumni (Undergraduate Students)
-    </summary>
-    <ul type="square">
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Sunpill Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Dongyoung Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Jaeyong Ahn</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Jungmin Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Suryun Ji</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Eunwoo Im</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Taesam Kim (Hyundai Mobis)</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Bora Jeong</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Chanwoo Hwang</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Dongsoo Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Hyunjung Son</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Seongae Baek</b><span style="float:right;"> <i></i></span></p>
-    </li>
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Sangyoon Shin</b><span style="float:right;"> <i></i></span></p>
-    </li>      
-        <li><p style="text-align:left;"><b sytle="font-size:120%;">Yunjeong Heo</b><span style="float:right;"> <i></i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Seunghun Paik</b><span style="float:right;"> <i></i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Minsu Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Hyeonkyu Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Yunki Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>
-      <li><p style="text-align:left;"><b sytle="font-size:120%;">Heejin Kim</b><span style="float:right;"> <i></i></span></p>
-    </li>  
-    </ul>
-</details>
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Chanwoo.jpg" alt="Chanwoo Hwang" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Chanwoo Hwang</span>
+            <span class="cna-member-role">Integrated Ms&amp;Ph.D</span>
+            <span class="cna-member-motto">To doubt is safer than to be secure.</span>
+            <span class="cna-member-interests">AI Security · Deep Learning Algorithm · Computer Vision</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Awards</h4>
+        <ul>
+          <li>2021 Academic Seminar, College of Natural Science, Hanyang University — Participation Prize.</li>
+        </ul>
+      </div>
+    </details>
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/hyunjung.jpg" alt="Hyunjung Son" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Hyunjung Son</span>
+            <span class="cna-member-role">Integrated Ms&amp;Ph.D</span>
+            <span class="cna-member-motto">Study without desire spoils the memory.</span>
+            <span class="cna-member-interests">Cryptography</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <p><em>“Study without desire spoils the memory, and it retains nothing that it takes in.”</em> — Leonardo da Vinci</p>
+      </div>
+    </details>
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/Seunghun.jpg" alt="Seunghun Paik" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <a class="cna-member-name" href="https://sites.google.com/view/seunghunpaik/home?authuser=0">Seunghun Paik<span class="cna-ext">↗</span></a>
+            <span class="cna-member-role">Integrated Ms&amp;Ph.D</span>
+            <span class="cna-member-motto">Be professional; be sceptical on your work.</span>
+            <span class="cna-member-interests">Privacy Preserving Machine Learning</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <p>“Be professional; be sceptical on your work.” — Terrence Tao</p>
+        <h4>Selected Publications</h4>
+        <ul>
+          <li>Bora Jeong, Sunpill Kim, Seunghun Paik, and Jae Hong Seo, <i>Analysis on Secure Triplet Loss</i>, IEEE Access, 2022.</li>
+          <li>Seunghun Paik, Sunpill Kim, and Jae Hong Seo, <i>Analysis on Locality Sensitive Hashing-based Biometric Template Protection Schemes</i>, BMVC 2023.</li>
+        </ul>
+        <h4>Awards</h4>
+        <ul>
+          <li>2022 Cryptanalysis Contest, Military Cryptography Research Center — Excellence Award.</li>
+          <li>2019 Academic Seminar, College of Natural Science, Hanyang University — Excellence Prize.</li>
+        </ul>
+      </div>
+    </details>
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/minsu.jpg" alt="Minsu Kim" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Minsu Kim</span>
+            <span class="cna-member-role">Integrated Ms&amp;Ph.D</span>
+            <span class="cna-member-motto">Better than yesterday.</span>
+            <span class="cna-member-interests">Biometric Template Protection (BTP)</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Awards</h4>
+        <ul>
+          <li>2022 Cryptanalysis Contest, Military Cryptography Research Center — Excellence Award.</li>
+          <li>2022 Academic Seminar, College of Natural Science, Hanyang University — Excellence Prize.</li>
+        </ul>
+      </div>
+    </details>
+
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Master's Student</h2>
+    <span class="cna-roster-count">1</span>
+  </div>
+  <div class="cna-roster-grid">
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/yunki.jpg" alt="Yunki Kim" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Yunki Kim</span>
+            <span class="cna-member-role">Master's Student</span>
+            <span class="cna-member-motto">Grow happiness under your feet.</span>
+            <span class="cna-member-interests">Cryptography</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <p>“The foolish man seeks happiness in the distance, the wise man grows it under his feet.” — James Oppenheim</p>
+        <h4>Awards</h4>
+        <ul>
+          <li>2023 Academic Seminar, College of Natural Science, Hanyang University — Encouragement Prize.</li>
+        </ul>
+      </div>
+    </details>
+
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Undergraduate Student</h2>
+    <span class="cna-roster-count">3</span>
+  </div>
+  <div class="cna-roster-grid">
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/insookim.jpeg" alt="Insoo Kim" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Insoo Kim</span>
+            <span class="cna-member-role">Undergraduate</span>
+            <span class="cna-member-motto">No pain, no gain.</span>
+            <span class="cna-member-interests">AI Security · Computer Vision</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <h4>Research Interests</h4>
+        <p>AI Security, Computer Vision</p>
+      </div>
+    </details>
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/hyeonminjang.jpeg" alt="Hyeonmin Jang" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Hyeonmin Jang</span>
+            <span class="cna-member-role">Undergraduate</span>
+            <span class="cna-member-motto">Change direction or end where you began.</span>
+            <span class="cna-member-interests">Cryptography</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <p>“If you do not change direction, you may end up where you were heading.”</p>
+      </div>
+    </details>
+
+    <details class="cna-member">
+      <summary>
+        <div class="cna-member-card">
+          <img src="{{ site.url }}{{ site.baseurl }}/assets/images/ingeunyun.jpeg" alt="Ingeun Yun" class="cna-member-photo">
+          <div class="cna-member-meta">
+            <span class="cna-member-name">Ingeun Yun</span>
+            <span class="cna-member-role">Undergraduate</span>
+            <span class="cna-member-motto">One day or day one.</span>
+            <span class="cna-member-interests">Cryptography · Deep Learning Algorithms</span>
+          </div>
+        </div>
+      </summary>
+      <div class="cna-member-bio">
+        <p>“One day or day one, you decide.”</p>
+      </div>
+    </details>
+
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Alumni — PostDoc</h2>
+    <span class="cna-roster-count">1</span>
+  </div>
+  <div class="cna-alumni-grid">
+    <div class="cna-alum">
+      <span class="cna-alum-name">Heewon Chung</span>
+      <span class="cna-alum-affil">— Assistant Professor, Jeonbuk National University</span>
+      <span class="cna-alum-when">Left Dec 2021</span>
+    </div>
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Alumni — Ph.D</h2>
+    <span class="cna-roster-count">2</span>
+  </div>
+  <div class="cna-alumni-grid">
+    <div class="cna-alum">
+      <span class="cna-alum-name">Hyeonbum Lee</span>
+      <span class="cna-alum-affil">— Postdoc, Seoul National University</span>
+      <span class="cna-alum-when">Graduated Aug 2025</span>
+    </div>
+    <div class="cna-alum">
+      <span class="cna-alum-name">Sunpill Kim</span>
+      <span class="cna-alum-affil">— Postdoc, Hanyang University</span>
+      <span class="cna-alum-when">Graduated Feb 2026</span>
+    </div>
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Alumni — Master</h2>
+    <span class="cna-roster-count">7</span>
+  </div>
+  <div class="cna-alumni-grid">
+    <div class="cna-alum"><span class="cna-alum-name">Hwamin Yoo</span><span class="cna-alum-when">Feb 2017</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Changjin Kim</span><span class="cna-alum-when">Feb 2017</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Gyumin Lim</span><span class="cna-alum-affil">— KAIST Cyber Security Research Center</span><span class="cna-alum-when">Feb 2021</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Chanyang Ju</span><span class="cna-alum-when">Feb 2023</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Gwangwoon Lee</span><span class="cna-alum-affil">— ArtygenSpace</span><span class="cna-alum-when">Aug 2024</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Kyuhwan Lee</span><span class="cna-alum-affil">— Korean National Police Agency</span><span class="cna-alum-when">Aug 2024</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span><span class="cna-alum-when">Aug 2024</span></div>
+  </div>
+</section>
+
+<section class="cna-roster" markdown="0">
+  <div class="cna-roster-head">
+    <h2>Alumni — Undergraduate</h2>
+    <span class="cna-roster-count">19</span>
+  </div>
+  <div class="cna-alumni-grid">
+    <div class="cna-alum"><span class="cna-alum-name">Sunpill Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Dongyoung Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Jaeyong Ahn</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Jungmin Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Suryun Ji</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Eunwoo Im</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Taesam Kim</span><span class="cna-alum-affil">— Hyundai Mobis</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Bora Jeong</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Chanwoo Hwang</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Dongsoo Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Hyunjung Son</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Seongae Baek</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Sangyoon Shin</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Yunjeong Heo</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Seunghun Paik</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Minsu Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Hyeonkyu Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Yunki Kim</span></div>
+    <div class="cna-alum"><span class="cna-alum-name">Heejin Kim</span></div>
+  </div>
+</section>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -10,129 +10,11 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Yesteryear&display=swap" rel="stylesheet">
-
-<style type="text/css">
-.cna-roster{ margin:0; }
-.cna-roster-head{
-  display:flex; align-items:baseline; gap:12px;
-  margin:28px 0 14px; padding-bottom:6px;
-  border-bottom:1px solid #f0ecdf;
-}
-.cna-roster-head h2{
-  margin:0; padding:0; border:none;
-  font-size:1.25rem; font-weight:700; color:#1f2227;
-}
-.cna-roster-count{
-  font-size:12px; color:#52575f; font-weight:600;
-  padding:2px 10px; background:#eeece7; border-radius:999px;
-}
-
-.cna-roster-grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fill, minmax(290px, 1fr));
-  gap:16px;
-}
-
-.cna-member{
-  background:#fff; border:1px solid #e6e2d8; border-radius:14px;
-  overflow:hidden;
-  box-shadow:0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
-  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
-}
-.cna-member:hover{
-  border-color:#c8c2b2;
-  transform:translateY(-2px);
-  box-shadow:0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
-}
-.cna-member[open]{
-  border-color:#b8740a;
-}
-.cna-member > summary{
-  cursor:pointer; user-select:none; list-style:none;
-  outline:none;
-}
-.cna-member > summary::-webkit-details-marker{ display:none; }
-
-.cna-member-card{
-  display:flex; gap:14px; padding:16px 16px;
-  align-items:flex-start;
-}
-.cna-member-photo{
-  width:88px; height:88px; border-radius:12px;
-  object-fit:cover; flex:0 0 88px;
-  background:#f4f0e2;
-}
-.cna-member-meta{ min-width:0; display:flex; flex-direction:column; gap:2px; flex:1; }
-.cna-member-name{
-  font-size:16px; font-weight:600; color:#1f2227; text-decoration:none;
-  line-height:1.2;
-}
-.cna-member-name:hover{ text-decoration:underline; }
-.cna-member-name .cna-ext{ font-size:11px; opacity:.5; margin-left:3px; }
-.cna-member-role{
-  font-size:10.5px; color:#8a909a; letter-spacing:.08em;
-  text-transform:uppercase; font-weight:700;
-  margin-top:2px;
-}
-.cna-member-motto{
-  font-family:'Yesteryear', cursive;
-  font-size:18px; color:#b8740a;
-  line-height:1.15; margin-top:6px;
-}
-.cna-member-interests{
-  font-size:12.5px; color:#52575f; margin-top:6px; line-height:1.45;
-}
-
-.cna-member-bio{
-  padding:0 18px 16px;
-  border-top:1px solid #f0ecdf;
-  font-size:13.5px; line-height:1.55; color:#1f2227;
-}
-.cna-member-bio h4{
-  font-size:11px; letter-spacing:.1em; text-transform:uppercase;
-  color:#8a909a; font-weight:700; margin:14px 0 6px;
-  border:none; padding:0;
-}
-.cna-member-bio ul{ padding-left:1.1em; margin:0; }
-.cna-member-bio li{ margin-bottom:4px; }
-.cna-member-bio .cna-edu{ width:100%; border-collapse:collapse; font-size:13.5px; }
-.cna-member-bio .cna-edu td{ padding:3px 0; border:none; vertical-align:top; }
-.cna-member-bio .cna-edu td:nth-child(1){ font-weight:500; }
-.cna-member-bio .cna-edu td:nth-child(2){ color:#52575f; font-style:italic; padding:0 12px; }
-.cna-member-bio .cna-edu td:nth-child(3){ color:#8a909a; font-size:12.5px; text-align:right; white-space:nowrap; }
-
-/* Alumni — denser, no photo */
-.cna-alumni-grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fill, minmax(240px, 1fr));
-  gap:0 24px;
-  margin-top:8px;
-}
-.cna-alum{
-  font-size:13.5px; color:#1f2227;
-  padding:10px 0;
-  border-bottom:1px solid #f4f0e2;
-}
-.cna-alum-name{ font-weight:600; }
-.cna-alum-affil{ color:#52575f; font-size:12.5px; }
-.cna-alum-when{ display:block; color:#8a909a; font-size:11.5px; margin-top:2px; letter-spacing:.04em; }
-
-@media (max-width:760px){
-  .cna-roster-grid{ grid-template-columns:1fr; }
-  .cna-alumni-grid{ grid-template-columns:1fr; }
-  .cna-member-card{ flex-direction:column; }
-  .cna-member-photo{ width:96px; height:96px; flex:0 0 96px; }
-}
-</style>
-
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Professor</h2>
-    <span class="cna-roster-count">1</span>
-  </div>
+    <span class="cna-section-count">1</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member" open>
@@ -161,11 +43,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Postdoc</h2>
-    <span class="cna-roster-count">1</span>
-  </div>
+    <span class="cna-section-count">1</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member">
@@ -202,11 +84,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Ph.D Student</h2>
-    <span class="cna-roster-count">1</span>
-  </div>
+    <span class="cna-section-count">1</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member">
@@ -230,11 +112,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Ms &amp; Ph.D Integrated Course</h2>
-    <span class="cna-roster-count">4</span>
-  </div>
+    <span class="cna-section-count">4</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member">
@@ -325,11 +207,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Master's Student</h2>
-    <span class="cna-roster-count">1</span>
-  </div>
+    <span class="cna-section-count">1</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member">
@@ -356,11 +238,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Undergraduate Student</h2>
-    <span class="cna-roster-count">3</span>
-  </div>
+    <span class="cna-section-count">3</span>
+  </header>
   <div class="cna-roster-grid">
 
     <details class="cna-member">
@@ -418,11 +300,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Alumni — PostDoc</h2>
-    <span class="cna-roster-count">1</span>
-  </div>
+    <span class="cna-section-count">1</span>
+  </header>
   <div class="cna-alumni-grid">
     <div class="cna-alum">
       <span class="cna-alum-name">Heewon Chung</span>
@@ -432,11 +314,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Alumni — Ph.D</h2>
-    <span class="cna-roster-count">2</span>
-  </div>
+    <span class="cna-section-count">2</span>
+  </header>
   <div class="cna-alumni-grid">
     <div class="cna-alum">
       <span class="cna-alum-name">Hyeonbum Lee</span>
@@ -451,11 +333,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Alumni — Master</h2>
-    <span class="cna-roster-count">7</span>
-  </div>
+    <span class="cna-section-count">7</span>
+  </header>
   <div class="cna-alumni-grid">
     <div class="cna-alum"><span class="cna-alum-name">Hwamin Yoo</span><span class="cna-alum-when">Feb 2017</span></div>
     <div class="cna-alum"><span class="cna-alum-name">Changjin Kim</span><span class="cna-alum-when">Feb 2017</span></div>
@@ -467,11 +349,11 @@ header:
   </div>
 </section>
 
-<section class="cna-roster" markdown="0">
-  <div class="cna-roster-head">
+<section class="cna-roster cna-section" markdown="0">
+  <header class="cna-section-head">
     <h2>Alumni — Undergraduate</h2>
-    <span class="cna-roster-count">19</span>
-  </div>
+    <span class="cna-section-count">19</span>
+  </header>
   <div class="cna-alumni-grid">
     <div class="cna-alum"><span class="cna-alum-name">Sunpill Kim</span></div>
     <div class="cna-alum"><span class="cna-alum-name">Dongyoung Kim</span></div>

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -7,7 +7,7 @@ permalink: /Members/
 excerpt: 'Anyone interested in our C&A Lab is always welcome!'
 header:
   overlay_image: /assets/images/crypt1.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 <section class="cna-roster cna-section" markdown="0">

--- a/_pages/Members.md
+++ b/_pages/Members.md
@@ -15,8 +15,8 @@ header:
   <a class="cna-page-toc-item" href="#professor">Professor</a>
   <a class="cna-page-toc-item" href="#postdoc">Postdoc</a>
   <a class="cna-page-toc-item" href="#phd-student">Ph.D</a>
-  <a class="cna-page-toc-item" href="#integrated-course">Integrated</a>
-  <a class="cna-page-toc-item" href="#masters-student">Master's</a>
+  <a class="cna-page-toc-item" href="#integrated-course">MS&amp;Ph.D</a>
+  <a class="cna-page-toc-item" href="#masters-student">Master</a>
   <a class="cna-page-toc-item" href="#undergrad">Undergrad</a>
   <a class="cna-page-toc-item" href="#alumni-postdoc">Alumni</a>
 </nav>

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -12,1833 +12,2337 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 # Previous Events
+
 ## Previous News
 
-<details open>
-  <summary style="font-size:1.2rem; font-weight:bold;">
-    2025
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2025</h3>
+    <span class="cna-year-count">19 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
-  <ul type="square">
-    <li>
-      (Dec 22, 2025) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo</b><br><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-      (Dec 03, 2025) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE T-BIOM</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-      (Nov 20, 2025) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">ASIACCS</span></b> 2026.
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung <br><i>Scalable Private Set Intersection over Distributed Encrypted Data</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-      (Nov 15, 2025) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE TDSC</span></b>.
-      <ul type="disc">
-          <li>
-            <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-      (Oct 23, 2025) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">NDSS</span></b> 2026.
-      <ul type="disc">
-          <li>
-             Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung<br><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i>
-          </li>
-      </ul>
-  </li>
-  <li>
-        (Oct 15, 2025)  <b>Sunpill Kim</b> and <b>Chanwoo Hwang</b>, members of our lab, will be giving a talk at the Hanyang University Mathematics Colloquium on the following topics.
-        <ul type="disc">
-            <li>
-              Date & Place : 04:00 PM, Oct 16 / Natural Science Building 206
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Dec 22, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          <ul>
+            <li><b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo</b><br><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Dec 03, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE T-BIOM</b>.
+          <ul>
+            <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Nov 20, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ASIACCS</b> 2026.
+          <ul>
+            <li><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>Scalable Private Set Intersection over Distributed Encrypted Data</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Nov 15, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE TDSC</b>.
+          <ul>
+            <li><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Oct 23, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">NDSS</b> 2026.
+          <ul>
+            <li>Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung<br><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">Oct 15, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Sunpill Kim</b> and <b>Chanwoo Hwang</b>, members of our lab, will be giving a talk at the Hanyang University Mathematics Colloquium on the following topics.
+          <ul>
+            <li>Date &amp; Place : 04:00 PM, Oct 16 / Natural Science Building 206</li>
+            <li>Topic 1 : <i>Non-Adaptive Adversarial Face Generation</i></li>
+            <li>Topic 2 : <i>Scores Know Bob's Voice: Non-Adaptive Speaker Impersonation Attack</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Sep 23, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2025.
+          <ul>
+            <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>Scalable Private Membership Test over Distributed and Encrypted Data</i></li>
+              </ul>
             </li>
-            <li>
-              Topic 1 : <i>Non-Adaptive Adversarial Face Generation</i>              
+            <li>The following 2 papers won the Special Award. Congrats all authors who participated in these submissions.
+              <ul>
+                <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b><br><i>Non-Adaptive Adversarial Face Generation</i></li>
+                <li><b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Know Bob's Voice: Non-Adaptive Speaker Impersonation Attack</i></li>
+              </ul>
             </li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Sep 19, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">NeurIPS</b> 2025.
+          <ul>
+            <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b><br><i>Non-Adaptive Adversarial Face Generation</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Sep 07, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following 2 papers have been accepted for presentation at <b style="color:var(--cna-indigo)">IEEE ICTC</b> 2025.
+          <ul>
+            <li><b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>A Survey of Model Inversion Attacks on Image Domain</i></li>
+            <li><b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>A Survey on Fuzzy Private Set Intersection Protocols</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Aug 28, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following 2 projects supported by the <b style="color:var(--cna-amber)">National Research Foundation of Korea (NRF)</b> have started.
+          <ul>
+            <li><i>Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems</i></li>
+            <li><i>A Study of Fuzzy Private Set Intersection</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Conference</span>
+          <time class="cna-card-meta">Aug 4, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Seunghun Paik</b> has been invited to give a poster presentation at the <b style="color:var(--cna-indigo)">KCCV</b> 2025.
+          <ul>
+            <li>Date &amp; Place : 02:30 PM, Aug 6 / BEXCO, Busan, Korea</li>
+            <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Jul 23, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Yunki Kim</b> visited the University of Notre Dame to do research on private set intersection protocols and their applications for six months. We wish success in his journey to become a good researcher!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Jul 19, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Hyunjung Son</b> visited the University of Notre Dame to do research on the security technologies to protect data copyright for a month. We wish success in her journey to become a good researcher!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jun 26, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ICCV</b> 2025.
+          <ul>
+            <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b><br><i>IDFace: Face Template Protection for Efficient and Secure Identification</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jun 22, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ESORICS</b> 2025.
+          <ul>
+            <li>Jaehwan Park, <b>Hyeonbum Lee</b>, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim<br><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">Jun 5, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          Doctor Mahdi Sedaghat from COSIC, KU Leuven, and founder of Soundness Labs will visit the C&amp;A lab. He will give a lecture and discuss joint research.
+          <ul>
+            <li>Date &amp; Place : 01:00 PM, May 20 / Natural Science Building 701</li>
+            <li>Title : <i>Translating Zero-Knowledge Research into Real-World Web3 Solutions: zkLogin and More</i></li>
             <li>
-              Topic 2 : <i>Scores Know Bob’s Voice: Non-Adaptive Speaker Impersonation Attack</i>              
+              <details>
+                <summary>(For the lecture abstract, click the arrow.)</summary>
+                <b>Abstract</b>: In this talk, I will share some of my recent works on bringing zk to real-world usecases. As the main part of the talk, I will discuss how zkLogin has simplified users' onboarding process by using identity tokens from platforms like Google or Facebook to authenticate transactions. Instead of managing new secrets, users can sign in with their existing accounts, and zero-knowledge proofs ensure that the link between a user's off-chain and on-chain identity stays hidden. Since its launch on the Sui blockchain, zkLogin has processed over 7 million zkLogin-signed transactions, containing around 2.5 million unique Zero-Knowledge Proofs (as of March 17, 2025), making it one of the most widely used zkApp. Additionally I will cover some extra use-cases like targeted Airdrops.
+              </details>
             </li>
-        </ul>
-  </li>
-  <li>
-        (Sep 23, 2025) Papers led by C&A members won several awards at the <b><span style = "color : #08A709">National Cryptographic Technology Contest</span></b>, 2025.
-        <ul type="disc">
-          <li>
-            The following paper won the Excellence Award. Congrats all authors who participated in this submission.
-          <ul type="circle">
-            <li>             
-              <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung
-            <br>
-              <i>Scalable Private Membership Test over Distributed and Encrypted Data</i>
-            </li> 
-          </ul>  
-          </li>
-          <li>
-            The following 2 papers won the Special Award. Congrats all authors who participated in these submissions.
-            <ul type="circle">
-              <li>
-                 <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b><br><i>Non-Adaptive Adversarial Face Generation</i>
-              </li>
-              <li>
-                 <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Know Bob’s Voice: Non-Adaptive Speaker Impersonation Attack</i>
-              </li>
-            </ul>
-          </li>
-        </ul>
-   </li>
-  <li>
-      (Sep 19, 2025) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">NeurIPS</span></b> 2025.
-      <ul type="disc">
-          <li>
-            <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b><br><i>Non-Adaptive Adversarial Face Generation</i>
-          </li>
-      </ul>
-  </li>
-  <li>
-      (Sep 07, 2025) The following 2 papers have been accepted for presentation at <b><span style = "color : #4169E1">IEEE ICTC</span></b> 2025.
-      <ul type="disc">
-          <li>
-             <b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>A Survey of Model Inversion Attacks on Image Domain</i>
-          </li>
-          <li>
-             <b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>A Survey on Fuzzy Private Set Intersection Protocols</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-      (Aug 28, 2025) The following 2 projects supported by the <b><span style = "color : #E8751A">National Research Foundation of Korea (NRF)</span></b> have started.
-      <ul type="disc">
-          <li>
-             <i>Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems</i>
-          </li>
-          <li>
-             <i>A Study of Fuzzy Private Set Intersection</i>
-          </li> 
-      </ul>
-  </li>
-  <li>
-        (Aug 4, 2025) <b>Seunghun Paik</b> has been invited to give a poster presentation at the <b><span style="color:#4169E1">KCCV</span></b> 2025.
-        <ul type="disc">
-            <li>
-              Date & Place : 02:30 PM, Aug 6 / BEXCO, Busan, Korea
-            </li>
-            <li>
-               <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i>
-            </li>  
-        </ul>
-  </li>
-  <li>
-    (Jul 23, 2025) <b>Yunki Kim</b> visited the University of Notre Dame to do research on private set intersection protocols and their applications for six months. We wish success in his journey to become a good researcher!
-  </li>   
-  <li>
-    (Jul 19, 2025) <b>Hyunjung Son</b> visited the University of Notre Dame to do research on the security technologies to protect data copyright for a month. We wish success in her journey to become a good researcher!
-  </li>   
-  <li>
-      (Jun 26, 2025) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">ICCV</span></b> 2025.
-      <ul type="disc">
-          <li>
-             <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b><br><i>IDFace: Face Template Protection for Efficient and Secure Identification</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-      (Jun 22, 2025) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">ESORICS</span></b> 2025.
-      <ul type="disc">
-          <li>
-             Jaehwan Park, <b>Hyeonbum Lee</b>, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim<br><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-        (Jun 5, 2025)  Doctor Mahdi Sedaghat from COSIC, KU Leuven, and founder of Soundness Labs will visit the C&A lab. He will give a lecture and discuss joint research.
-        <ul type="disc">
-            <li>
-              Date & Place : 01:00 PM, May 20 / Natural Science Building 701
-            </li>
-            <li>
-              Title : <i>Translating Zero-Knowledge Research into Real-World Web3 Solutions: zkLogin and More</i>              
-            </li>
-            <details>
-                <summary>
-                    (For the lecture abstract, click the arrow.)
-                </summary>
-               <b>Abstract</b>: In this talk, I will share some of my recent works on bringing zk to real-world usecases. As the main part of the talk, I will discuss how zkLogin has simplified users' onboarding process by using identity tokens from platforms like Google or Facebook to authenticate transactions. Instead of managing new secrets, users can sign in with their existing accounts, and zero-knowledge proofs ensure that the link between a user’s off-chain and on-chain identity stays hidden. Since its launch on the Sui blockchain, zkLogin has processed over 7 million zkLogin-signed transactions, containing around 2.5 million unique Zero-Knowledge Proofs (as of March 17, 2025), making it one of the most widely used zkApp. Additionally I will cover some extra use-cases like targeted Airdrops.
-            </details>
-        </ul>
-  </li>
-  <li>
-        (Apr 8, 2025)  Dongsoo Kim, a member of our lab, will be giving a talk at the Hanyang University Mathematics Colloquium on the following topic.
-        <ul type="disc">
-            <li>
-              Date & Place : 04:00 PM, Apr 8 / Natural Science Building B119
-            </li>
-            <li>
-              Title : <i>Certifiable robustness: Theoretically guaranted defence method against adversarial attacks on deep learning models</i>              
-            </li>
-        </ul>
-  </li>
-  <li>
-      (Feb 27, 2025) The following project supported by the <b><span style = "color : #E8751A">Korea Institute of Information Security & Cryptology (KIISC)</span></b> has started.
-      <ul type="disc">
-          <li>
-             <i>Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-    (Feb 10, 2025) Ph.D. <b>Heewon Chung</b>, a former postdoctoral researcher from our lab, has been appointed as an Assistant Professor in the Department of Software Engineering at Jeonbuk National University (전북대학교 소프트웨어공학과) in South Korea.
-  </li>
-  <li>
-      (Jan 1, 2025) The following paper has been accepted for publication at <b><span style = "color : #DC143C">Pattern Recognition</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b><br><i>Deep Face Template Protection in the Wild</i>
-          </li>  
-      </ul>
-  </li>
-  </ul>  
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">Apr 8, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          Dongsoo Kim, a member of our lab, will be giving a talk at the Hanyang University Mathematics Colloquium on the following topic.
+          <ul>
+            <li>Date &amp; Place : 04:00 PM, Apr 8 / Natural Science Building B119</li>
+            <li>Title : <i>Certifiable robustness: Theoretically guaranted defence method against adversarial attacks on deep learning models</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Feb 27, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following project supported by the <b style="color:var(--cna-amber)">Korea Institute of Information Security &amp; Cryptology (KIISC)</b> has started.
+          <ul>
+            <li><i>Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Feb 10, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          Ph.D. <b>Heewon Chung</b>, a former postdoctoral researcher from our lab, has been appointed as an Assistant Professor in the Department of Software Engineering at Jeonbuk National University (전북대학교 소프트웨어공학과) in South Korea.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jan 1, 2025</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">Pattern Recognition</b>.
+          <ul>
+            <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b><br><i>Deep Face Template Protection in the Wild</i></li>
+          </ul>
+        </div>
+      </article>
+
+    </div>
+  </div>
 </details>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-      2024
-    </summary>
-    <ul type="square">
-  <li>
-    (Dec 24, 2024) <b>Seunghun Paik</b> visit in the University of Notre Dame to do research on private set intersection protocols and their applications during six months. We wish his successful journeys to become good researchers!
-  </li>    
-  <li>
-    (Oct 15, 2024) <b>Seunghun Paik</b> (MS-PhD Integrated Student) was selected as an excellent trainee in the National Cryptography Expert Training course (암호전문인력양성교육) conducted by the National Security Research Institute. Congrats Seunghun!
-  </li>
-   <li>
-        (Oct 11, 2024) Papers led by C&A members won several awards at the <b><span style = "color : #08A709">National Cryptographic Technology Contest</span></b>, 2024.
-        <ul type="disc">
-          <li>
-            The following paper won the Excellence Award. Congrats all authors who participated in this submission.
-          <ul type="circle">
-            <li>             
-              <b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim
-            <br>
-              <i>UTRA: Universe Token Reusability Attack and Verifiable Delegatable Order-Revealing Encryption</i>
-            </li> 
-          </ul>  
-          </li>
-          <li>
-            The following paper won the Encouragement Award. Congrats all authors who participated in this submission.
-            <ul type="circle">
-            <li>             
-              <b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b>
-            <br>
-              <i>On the Security-Accuracy Trade-off of Hash-based Face Template Protections</i>
-            </li> 
-            </ul>   
-          </li>
-        </ul>
-  </li>
-  <li>
-        (Oct 1, 2024) HUCC, Crypto Club of Hanyang University, won the Encouragement Award (장려상) in <b><span style = "color : #08A709">Cryptanalysis Contest</span></b>, 2024, hosted by Military Crypto Research Center. Congrats two of C&A members, <b>Yunki Kim</b>, and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
-  </li>
-  <li>
-      (Jul 1, 2024) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">ECCV</span></b> 2024.
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i>
-          </li>  
-      </ul>
-  </li>
-  <li>
-      (Jun 24, 2024) The following 2 projects supported by <b><span style = "color : #E8751A">National Research Foundation of Korea (NRF)</span></b> have started.
-      <ul type="disc">
-          <li>
-             <i>Secure Authentication System using Deep Learning-based Biometric Recognition System</i>
-          </li>
-          <li>
-             <i>A Study on Incremetally Verifiable Computation through Zero-Knowledge Proof</i>
-          </li> 
-      </ul>
-  </li>
-  <li>
-      (Jun 7, 2024) The following paper has been accepted for presentation at <b><span style = "color : #4169E1">CISC-S</span></b> 2024. Also, this paper won the Excellenct Paper Award. 
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>On the Certifiable Robustness of Face Recognition Systems</i>
-          </li>  
-      </ul>
-   </li>
-  <li>
-        (Jun 5, 2024)  Professor Taeho Jung from the University of Notre Dame will visit C&A lab. He will give a lecture and discuss joint research.
-        <ul type="disc">
-            <li>
-              Date & Place : 04:00 PM, June 5 / Natural Science building 702
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2024</h3>
+    <span class="cna-year-count">12 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Dec 24, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Seunghun Paik</b> visit in the University of Notre Dame to do research on private set intersection protocols and their applications during six months. We wish his successful journeys to become good researchers!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Program</span>
+          <time class="cna-card-meta">Oct 15, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Seunghun Paik</b> (MS-PhD Integrated Student) was selected as an excellent trainee in the National Cryptography Expert Training course (암호전문인력양성교육) conducted by the National Security Research Institute. Congrats Seunghun!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Oct 11, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2024.
+          <ul>
+            <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim<br><i>UTRA: Universe Token Reusability Attack and Verifiable Delegatable Order-Revealing Encryption</i></li>
+              </ul>
             </li>
-            <li>
-              Title : <i>A Scalable Variant of Private Set Intersection</i>              
+            <li>The following paper won the Encouragement Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>On the Security-Accuracy Trade-off of Hash-based Face Template Protections</i></li>
+              </ul>
             </li>
-            <details>
-                <summary>
-                    (For lecture abstract, click the arrow)
-                </summary>
-               <b>Abstract</b>: Private Set Intersection (PSI) is a primitive that allows a querier to learn whether there is an intersection between a query set and another set held by a server. This is a privacy-preserving protocol because the querier does not learn anything about the server’s set, and the server does not learn anything about the querier’s set either. FHE-based protocols have advantages such as post-quantum security and asynchrony, but they have the downside of low scalability. The scalability bottleneck lies in the multiplicative nature of the homomorphic circuit evaluated during the PSI protocol. We present an addition-based variant of PSI that overcomes this scalability limit such that the PSI can be run against hundreds of thousands of servers.
-            </details>
-        </ul>
-    </li>
-  <li>(Apr 19, 2024) <b>Hyeonbum Lee</b> has been selected as a speaker for the submission proposal in the 6th <b><span style = "color : #4169E1">ZKProof workshop</span></b> in Berlin.
-   </li>
-   <li>(Apr 11, 2024) <b>Sunpill Kim</b> is selected as the 1st Graduate Presidential Science Scholarship recipient. (Ph.D. student in the Department of Mathematics, 2 finalists selected)
-   </li>
-   <li>
-      (Apr 1, 2024) The following project supported by <b><span style = "color : #E8751A">Korea Creative Content Agency (KOCCA)</span></b> has started.
-      <ul type="disc">
-          <li>
-             <i>International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology</i>
-          </li>  
-      </ul>
-   </li>
-   <li>
-      (Mar 1, 2024) The following paper has been accepted as a poster at <b><span style = "color : #4169E1">IEEE ICBC</span></b> 2024.
-      <ul type="disc">
-          <li>
-             <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i>
-          </li>  
-      </ul>
-  </li>
-  <li>(Feb 5, 2024) <b>Chanwoo Hwang</b> and <b>Dongsoo Kim</b> visit in the Singapore A*STAR to participate short-term research for top international students during five months. We wish their successful journeys to become good researchers!
-   </li>
-   <li>
-      (Feb 5, 2024) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE TDSC</span></b>.
-      <ul type="disc">
-          <li>
-             Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung<br><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i>
-          </li>  
-      </ul>
-   </li>
-</ul>   
-</details>
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-      2023
-    </summary>
-    <ul type="square">
-      <li>
-      (Oct 29, 2023) The following paper has been accepted for presentation at the <b><span style = "color : #4169E1">IEEE S&P</span></b> 2024.
-      <ul type="disc">
-          <li>
-             <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i>
-          </li>  
-      </ul>
-   </li>
-   <li>
-        (Oct 4, 2023) Papers led by C&A members won several awards at the <b><span style = "color : #08A709">National Cryptographic Technology Contest</span></b>, 2023.
-        <ul type="disc">
-          <li>
-            The following paper won the Excellence Award. Congrats all authors who participated in this submission.
-          <ul type="circle">
-            <li>             
-              <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b> 
-            <br>
-              <i>IDFace: Efficient and Secure Identification for Face Images</i>
-            </li> 
-          </ul>  
-          </li>
-          <li>
-            The following paper won the Encouragement Award. Congrats all authors who participated in this submission.
-            <ul type="circle">
-            <li>             
-              <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b> 
-            <br>
-              <i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i>
-            </li> 
-            </ul>   
-          </li>
-          <li>
-            The following paper won the Special Award. Congrats all authors who participated in this submission.
-            <ul type="circle">
-            <li>             
-              <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung
-            <br>
-              <i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i>
-            </li> 
-            </ul>
-          </li>
-        </ul>
-   </li>
-   <li>
-        (Sep 26, 2023) HUCC, Crypto Club of Hanyang University, won the Top Excellence Award (최우수상) in <b><span style = "color : #08A709">Cryptanalysis Contest</span></b>, 2023, hosted by Military Crypto Research Center. Congrats three of C&A members, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, and <b>Minsu Kim</b>, who are a leader and two members of HUCC.
-    </li>
-   <li>
-      (Aug 22, 2023) The following paper has been accepted for presentation at the <b><span style = "color : #4169E1">BMVC </span></b>2023 <b>(Oral)</b>.
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes</i>
-          </li>  
-      </ul>
-    </li>
-    <li>
-      (Jul 25, 2023) The following paper has been accepted for publication in <b><span style = "color : #DC143C">IEEE TIFS</span></b>.
-      <ul type="disc">
-          <li>
-            Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo</b><br><i>Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption</i>
-          </li>  
-      </ul>
-    </li>   
-    <li>
-        (July 13, 2023)  There will be an invited lecture by Prof. Taeho Jung, Notre Dame. 
-        <ul type="disc">
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Oct 1, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          HUCC, Crypto Club of Hanyang University, won the Encouragement Award (장려상) in <b style="color:var(--cna-forest)">Cryptanalysis Contest</b>, 2024, hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Yunki Kim</b>, and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jul 1, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ECCV</b> 2024.
+          <ul>
+            <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Jun 24, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following 2 projects supported by <b style="color:var(--cna-amber)">National Research Foundation of Korea (NRF)</b> have started.
+          <ul>
+            <li><i>Secure Authentication System using Deep Learning-based Biometric Recognition System</i></li>
+            <li><i>A Study on Incremetally Verifiable Computation through Zero-Knowledge Proof</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Jun 7, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">CISC-S</b> 2024. Also, this paper won the Excellenct Paper Award.
+          <ul>
+            <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>On the Certifiable Robustness of Face Recognition Systems</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">Jun 5, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          Professor Taeho Jung from the University of Notre Dame will visit C&amp;A lab. He will give a lecture and discuss joint research.
+          <ul>
+            <li>Date &amp; Place : 04:00 PM, June 5 / Natural Science building 702</li>
+            <li>Title : <i>A Scalable Variant of Private Set Intersection</i></li>
             <li>
-              Date & Place : 10:30 AM, Jul 13 / Natural Science building 702
+              <details>
+                <summary>(For lecture abstract, click the arrow)</summary>
+                <b>Abstract</b>: Private Set Intersection (PSI) is a primitive that allows a querier to learn whether there is an intersection between a query set and another set held by a server. This is a privacy-preserving protocol because the querier does not learn anything about the server's set, and the server does not learn anything about the querier's set either. FHE-based protocols have advantages such as post-quantum security and asynchrony, but they have the downside of low scalability. The scalability bottleneck lies in the multiplicative nature of the homomorphic circuit evaluated during the PSI protocol. We present an addition-based variant of PSI that overcomes this scalability limit such that the PSI can be run against hundreds of thousands of servers.
+              </details>
             </li>
-            <li>
-              Title : <i>Cryptography and Blockchain for Secure and Private Web3 Ecosystem</i>              
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Conference</span>
+          <time class="cna-card-meta">Apr 19, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Hyeonbum Lee</b> has been selected as a speaker for the submission proposal in the 6th <b style="color:var(--cna-indigo)">ZKProof workshop</b> in Berlin.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Apr 11, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Sunpill Kim</b> is selected as the 1st Graduate Presidential Science Scholarship recipient. (Ph.D. student in the Department of Mathematics, 2 finalists selected)
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Apr 1, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following project supported by <b style="color:var(--cna-amber)">Korea Creative Content Agency (KOCCA)</b> has started.
+          <ul>
+            <li><i>International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Mar 1, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted as a poster at <b style="color:var(--cna-indigo)">IEEE ICBC</b> 2024.
+          <ul>
+            <li><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Feb 5, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Chanwoo Hwang</b> and <b>Dongsoo Kim</b> visit in the Singapore A*STAR to participate short-term research for top international students during five months. We wish their successful journeys to become good researchers!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Feb 5, 2024</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE TDSC</b>.
+          <ul>
+            <li>Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung<br><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i></li>
+          </ul>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2023</h3>
+    <span class="cna-year-count">12 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Oct 29, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">IEEE S&amp;P</b> 2024.
+          <ul>
+            <li><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Oct 4, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2023.
+          <ul>
+            <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b><br><i>IDFace: Efficient and Secure Identification for Face Images</i></li>
+              </ul>
             </li>
-            <details>
-                <summary>
-                    (For more information, click the arrow)
-                </summary>
-                <img src="{{ site.url }}{{ site.baseurl }}/assets/images/seminar_poster(07.13.23.).jpeg">
-            </details>
-        </ul>
-    </li>
-    <li>
-        (May 31, 2023)  The following paper has been accepted for publication in <b><span style = "color : #4169E1">IWSEC </span></b> 2023.
-        <ul type="disc">
+            <li>The following paper won the Encouragement Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></li>
+              </ul>
+            </li>
+            <li>The following paper won the Special Award. Congrats all authors who participated in this submission.
+              <ul>
+                <li><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung<br><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Sep 26, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          HUCC, Crypto Club of Hanyang University, won the Top Excellence Award (최우수상) in <b style="color:var(--cna-forest)">Cryptanalysis Contest</b>, 2023, hosted by Military Crypto Research Center. Congrats three of C&amp;A members, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, and <b>Minsu Kim</b>, who are a leader and two members of HUCC.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Aug 22, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">BMVC</b> 2023 <b>(Oral)</b>.
+          <ul>
+            <li><b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jul 25, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication in <b style="color:var(--cna-crimson)">IEEE TIFS</b>.
+          <ul>
+            <li>Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo</b><br><i>Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">Jul 13, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          There will be an invited lecture by Prof. Taeho Jung, Notre Dame.
+          <ul>
+            <li>Date &amp; Place : 10:30 AM, Jul 13 / Natural Science building 702</li>
+            <li>Title : <i>Cryptography and Blockchain for Secure and Private Web3 Ecosystem</i></li>
             <li>
-              <b>Hyeonbum Lee</b> and <b>Jae Hong Seo</b><br><i>TENET : Sublogarithmic Proof, Sublinear Verifier Inner Product Argument without a Trusted Setup</i>
-            </li>  
-        </ul>
-    </li> 
-    <li>
-      (May 13, 2023) Two of our members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, received the Top Academic Excellence Award (한양학업최우수상) from the President of Hanyang University.
-    </li>  
-    <li>
-      (Apr 20, 2023) The following paper has been accepted for publication in <b><span style = "color : #DC143C">Designs, Codes and Cryptography</span></b>.
-      <ul type="disc">
-          <li>
-            Hyung Tae Lee and <b>Jae Hong Seo</b><br><i>On the Security of Functional Encryption in the Generic Group Model</i>
-          </li>  
-      </ul>
-    </li>  
-    <li>
-      (Apr 20, 2023) Prof. <b>Jae Hong Seo</b> joins in the program committees of <b><span style = "color : #4169E1">ASIACRYPT</span></b> 2023 and <b><span style = "color : #4169E1">PQCrypto</span></b> 2023.
-    </li>
-    <li>
-        (Feb 14, 2023) <b>Bora Jeong</b> won the Grand Prize in the <b><span style = "color : #08A709">Best Research Paper Award</span></b> for graduate students by the Research Institute for Natural Sciences, Hanyang University.
-        <ul type="disc">
-          <li>
-            <b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>Analysis on Secure Triplet Loss.</i>
-          </li>  
-      </ul>
-    </li> 
-    <li>
-        (Jan 5, 2023) Our student captain, <b>Sunpill Kim</b>, visits A*STAR at Singapore, one of the world's leading research institutes, for a year-long collaborative research. We wish him success in his studies at A*STAR.
-    </li>
-    </ul>
-    <details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-       <b>23 Summer</b>
-    </summary>
-    <br>
-    <details>
-      <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        IVC
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 60px">
-    <col style="width: 90px">
-    <col style="width: 67px">
-    <col style="width: 150px">
-    <col style="width: 640px">
-    <col style="width: 67px">
-    <col style="width: 75px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="7">Seminar Schedule - IVC</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-        <td class="tg-c3ow">Material</td>
-        <td class="tg-c3ow">Blog Post</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">6/27</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">701</td>
-        <td class="tg-c3ow" rowspan="2">Hyeonbum Lee</td>
-        <td class="tg-c3ow" rowspan="2">Nova : Recursive Zero Knowledge Arguments from Folding Schemes(<A href="https://eprint.iacr.org/2021/370.pdf">DOI</A>)</td>
-        <td class="tg-c3ow" rowspan="2"></td>
-        <td class="tg-c3ow" rowspan="2"></td>
-      </tr>
-      <tr>     
-        <td class="tg-c3ow">7/6</td>
-      </tr>   
-      <tr>
-        <td class="tg-c3ow">7/11</td>
-        <td class="tg-c3ow">07:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Hyunjung Son</td>
-        <td class="tg-c3ow">SuperNova: Proving universal machine executions without universal circuits(<A href="https://eprint.iacr.org/2022/1758.pdf">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/18</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">701</td>
-        <td class="tg-c3ow" rowspan="2">Seongae Baek</td>
-        <td class="tg-c3ow" rowspan="2">Customizable constraint systems for succinct arguments(<A href="https://eprint.iacr.org/2023/552.pdf">DOI</A>)</td>
-        <td class="tg-c3ow" rowspan="2"></td>
-        <td class="tg-c3ow" rowspan="2"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/25</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/1</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow">751</td>
-        <td class="tg-c3ow" rowspan="2">Hyeonbum Lee</td>
-        <td class="tg-c3ow" rowspan="2">Hypernova : Recursive arguments for customizable constraint systems(<A href="https://eprint.iacr.org/2023/573.pdf">DOI</A>)</td>
-        <td class="tg-c3ow" rowspan="2"></td>
-        <td class="tg-c3ow" rowspan="2"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/8</td>
-        <td class="tg-c3ow">702</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">8/14</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow" rowspan="2">Hyunjung Son</td>
-        <td class="tg-c3ow" rowspan="2">Protostar : Generic Efficient Accumulation/Folding for Special-sound Protocols(<A href="https://eprint.iacr.org/2023/620.pdf">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">TBD</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      </tbody>
-      </table>
-    </details>
-    <br>
-    <details>
-      <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Deep Learning
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 60px">
-    <col style="width: 90px">
-    <col style="width: 67px">
-    <col style="width: 150px">
-    <col style="width: 640px">
-    <col style="width: 67px">
-    <col style="width: 75px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="7">Seminar Schedule - Deep Learning Paper</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-        <td class="tg-c3ow">Material</td>
-        <td class="tg-c3ow">Blog Post</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">7/12</td>
-        <td class="tg-c3ow" rowspan="2">10:00AM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Bora Jeong</td>
-        <td class="tg-c3ow">DeepFool: A simple and accurate method to fool deep neural networks  (CVPR'16)(<A href="https://arxiv.org/abs/1511.04599">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>     
-        <td class="tg-c3ow">Seunghun Paik</td>
-        <td class="tg-c3ow">Adversarial Examples Are Not Bugs, They Are Features (NIPS'19 Spotlight)(<A href="https://arxiv.org/pdf/1905.02175.pdf">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>   
-      <tr>
-        <td class="tg-c3ow" rowspan="2">7/19</td>
-        <td class="tg-c3ow" rowspan="2">10:00AM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Chanwoo Hwang</td>
-        <td class="tg-c3ow">Adversarial Patch (arXiv'17)(<A href="https://arxiv.org/pdf/1905.02175.pdf">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>     
-        <td class="tg-c3ow">Dongsoo Kim</td>
-        <td class="tg-c3ow">Efficient Decision-based Black-box Adversarial Attacks on Face Recognition (CVPR'19)(<A href="https://arxiv.org/pdf/1905.02175.pdf](https://openaccess.thecvf.com/content_CVPR_2019/papers/Dong_Efficient_Decision-Based_Black-Box_Adversarial_Attacks_on_Face_Recognition_CVPR_2019_paper.pdf)">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/26</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Minsu Kim</td>
-        <td class="tg-c3ow">Universal adversarial perturbations (CVPR'17)(<A href="https://arxiv.org/abs/1610.08401">DOI</A>)</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">8/2</td>
-        <td class="tg-c3ow" rowspan="2">10:00AM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Bora Jeong</td>
-        <td class="tg-c3ow">Iris Recognition</td>
-        <td class="tg-c3ow">(<A href="https://drive.google.com/file/d/1vo1CsLA-qk4vnqp5Sn1JcrqgJMqAtlR2/view?usp=drive_link" target = "_blank">LINK</A>)</td>
-        <td class="tg-c3ow">(<A href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-iris-recognition-iriscode.html" target = "_blank">LINK</A>)</td>
-      </tr>
-      <tr>     
-        <td class="tg-c3ow">Seunghun Paik</td>
-        <td class="tg-c3ow">Understanding Adversarial Examples</td>
-        <td class="tg-c3ow">(<A href="https://drive.google.com/file/d/1XJoMJjMt2eLpl36BZhRNa0sR4pQu1ynu/view?usp=drive_link" target = "_blank">LINK</A>)</td>
-        <td class="tg-c3ow">(<A href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-adversarial-example-understanding.html" target = "_blank">LINK</A>)</td>
-      </tr>
-       <tr>
-        <td class="tg-c3ow">8/9</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Chanwoo Hwang</td>
-        <td class="tg-c3ow">What is Dataset Distillation?</td>
-         <td class="tg-c3ow">(<A href="https://drive.google.com/file/d/1S9kC57d5g-psBJxS7qVjYT_inM8xfgl-/view?usp=drive_link" target = "_blank">LINK</A>)</td>
-        <td class="tg-c3ow">(<A href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-dataset-distillation-dataset.html" target = "_blank">LINK</A>)</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/16</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Dongsoo Kim</td>
-        <td class="tg-c3ow">Predictive Coding</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>      
-      <tr>     
-        <td class="tg-c3ow">8/30</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">TBA</td>
-        <td class="tg-c3ow">Hyeonkyu Kim</td>
-        <td class="tg-c3ow">Recurrent Neural Network</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">9/1</td>
-        <td class="tg-c3ow">03:00PM</td>
-        <td class="tg-c3ow">TBA</td>
-        <td class="tg-c3ow">Minsu Kim</td>
-        <td class="tg-c3ow">Fuzzy Extractor</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      </tbody>
-      </table>
-    </details>
-    <br>
-    <details>
-    <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        ZKP Basic
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 60px">
-    <col style="width: 90px">
-    <col style="width: 67px">
-    <col style="width: 150px">
-    <col style="width: 640px">
-    <col style="width: 67px">
-    <col style="width: 75px">  
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="7">Seminar Schedule - ZKP Basic</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-        <td class="tg-c3ow">Material</td>
-        <td class="tg-c3ow">Blog Post</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/07</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Junhee Cho</td>
-        <td class="tg-c3ow">proofs, interactive proofs, schwarz-zippel lemma, multilinear extension</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/14</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Yunki Kim</td>
-        <td class="tg-c3ow">sumcheck protocol</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/21</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Seongae Baek</td>
-        <td class="tg-c3ow">application of sum-check protocol</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/28</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Seongae Baek</td>
-        <td class="tg-c3ow">GKR protocol</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/04</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Junhee Cho<br>Yunki Kim</td>
-        <td class="tg-c3ow">non-interactive proofs, random oracle model, fiat-shamir heuristic
-argument of knowledge, knowledge soundness</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/10</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Yunki Kim</td>
-        <td class="tg-c3ow">zero-knowledge, sigma protocol</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow"></td>
-      </tr>
-      </tbody>
-      </table>
-    </details>
-</details>
-<br>
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        <b>22-23 Winter</b>
-    </summary>
-<br>  
-<details> 
-    <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Deep Learning
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 60px">
-    <col style="width: 90px">
-    <col style="width: 67px">
-    <col style="width: 150px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Deep Learning Paper</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">1/2</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2202.04557.pdf">Universal Hopfield Networks: A General Framework for Single-Shot Associative Memory Models</A></td>
-      </tr>
-      <tr>     
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://openaccess.thecvf.com/content/ICCV2021/papers/Yang_Towards_Face_Encryption_by_Generating_Adversarial_Identity_Masks_ICCV_2021_paper.pdf">Towards Face Encryption by Generating Adversarial Identity Masks</A></td>
-      </tr>      
-      <tr>
-        <td class="tg-c3ow" rowspan="2">1/16</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2205.12010.pdf">SFace: Sigmoid-Constrained Hypersphere Loss for Robust Face Recognition</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2207.10131.pdf">Continual variational autoencoder learning via online cooperative memorization</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/26</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Prof. Jaehong Seo</td>
-        <td class="tg-c3ow">Hopfield Network Summary</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">1/30</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://aaai-2022.virtualchair.net/poster_aaai88">AnchorFace: Boosting TAR@FAR for Practical Face Recognition</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2207.07316.pdf">Privacy-Preserving Face Recognition with Learnable Privacy Budgets in Frequency Domain</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">2/13</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">701</td>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://openaccess.thecvf.com/content/CVPR2022/html/Tan_Hyperspherical_Consistency_Regularization_CVPR_2022_paper.html">Hyperspherical Consistency Regularization</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/abs/2204.05502">CoupleFace: Relation Matters for Face Recognition Distillation</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">2/20</td>
-        <td class="tg-c3ow" rowspan="2">01:00PM</td>
-        <td class="tg-c3ow" rowspan="2">702</td>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9955645">QuantFace: Towards lightweight face recognition by synthetic data low-bit quantization</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2210.08013.pdf">On the Relationship Between Variational Inference and Auto-Associative Memory</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="2">TBD</td>
-        <td class="tg-c3ow" rowspan="2">TBD</td>
-        <td class="tg-c3ow" rowspan="2">TBD</td>
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://www.mdpi.com/2079-9292/11/23/3909">UFace: An Unsupervised Deep Learning Face Verification System</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9796565">Frontal-Centers Guided Face: Boosting Face Recognition by Learning Pose-Invariant  Features</A></td>
-      </tr>
-      </tbody>
-      </table>
+              <details>
+                <summary>(For more information, click the arrow)</summary>
+                <img src="{{ site.url }}{{ site.baseurl }}/assets/images/seminar_poster(07.13.23.).jpeg" style="width:50%; max-width:600px;">
+              </details>
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">May 31, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication in <b style="color:var(--cna-indigo)">IWSEC</b> 2023.
+          <ul>
+            <li><b>Hyeonbum Lee</b> and <b>Jae Hong Seo</b><br><i>TENET : Sublogarithmic Proof, Sublinear Verifier Inner Product Argument without a Trusted Setup</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">May 13, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          Two of our members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, received the Top Academic Excellence Award (한양학업최우수상) from the President of Hanyang University.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Apr 20, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for publication in <b style="color:var(--cna-crimson)">Designs, Codes and Cryptography</b>.
+          <ul>
+            <li>Hyung Tae Lee and <b>Jae Hong Seo</b><br><i>On the Security of Functional Encryption in the Generic Group Model</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Media</span>
+          <time class="cna-card-meta">Apr 20, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          Prof. <b>Jae Hong Seo</b> joins in the program committees of <b style="color:var(--cna-indigo)">ASIACRYPT</b> 2023 and <b style="color:var(--cna-indigo)">PQCrypto</b> 2023.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Feb 14, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Bora Jeong</b> won the Grand Prize in the <b style="color:var(--cna-forest)">Best Research Paper Award</b> for graduate students by the Research Institute for Natural Sciences, Hanyang University.
+          <ul>
+            <li><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>Analysis on Secure Triplet Loss.</i></li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Jan 5, 2023</time>
+        </header>
+        <div class="cna-card-body">
+          Our student captain, <b>Sunpill Kim</b>, visits A*STAR at Singapore, one of the world's leading research institutes, for a year-long collaborative research. We wish him success in his studies at A*STAR.
+        </div>
+      </article>
+
+    </div>
+  </div>
 </details>
 
-<br>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022</h3>
+    <span class="cna-year-count">16 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
 
-<details> 
-    <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Computational Number Theory & Algebra
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-l3ow{border-color:inherit;text-align:left;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Computational Number Theory & Algebra</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-3ow" colspan="5"><b>Book : A computational Introductiobn to Numver Theory and Algebra second Edition</b></td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-l3ow">Topic</td>
-      </tr>          
-      <tr>
-        <td class="tg-c3ow">1/5</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 1 ~ 4, Review on Number Theory and Integer Arithmetics</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/12</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 8 ~ 9, Probabilistic Distributions and Algorithms on <img src="https://latex.codecogs.com/svg.image?\inline&space;\mathbb{Z}_p" title="https://latex.codecogs.com/svg.image?\inline \mathbb{Z}_p" /></td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/19</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 10 ~ 12, More Probabilistic Algorithms on <img src="https://latex.codecogs.com/svg.image?\inline&space;\mathbb{Z}_p" title="https://latex.codecogs.com/svg.image?\inline \mathbb{Z}_p" /> (e.g. Miller-Rabin Test)</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/26</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 6,7,13,14, Groups, Rings, Modules, and Vector Spaces</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">2/2</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 16, More  on  Rings  (e.g.  Field Extension, PID, UFD, ...)</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">2/9</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 17 ~ 18, Polynomial Arithmetics, and Linearly Generated Sequences</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">2/16</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 19 ~ 20, Finite Fields, Algorithms for Finite Fields (e.g. Cantor-Zassenhaus  Algorithm)</td>       
-      </tr>
-      <tr>
-        <td class="tg-c3ow">2/23</td>
-        <td class="tg-c3ow">01:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-l3ow">Chap. 15, 21, Dixon’s Method, Index Calculus Method, and AKS Algorithm</td>       
-      </tr>
-    </tbody>
-    </table>
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Dec 10, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted in <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          <ul>
+            <li><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b>, "<i>Analysis on Secure Triplet Loss.</i>" (<a href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9965373">DOI</a>)</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Nov 11, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Bora Jeong</b> visits in the Singapore A*STAR to participate short-term research for top international students during four months. We wish her a successful journey to become good researchers!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Sep 27, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper won the grand prize at "<b style="color:var(--cna-forest)">National Cryptographic Technology Contest, 2022</b>". Congrats <b>Hyeonbum Lee</b>, who was the lead author of this submission.
+          <ul>
+            <li><b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b>, "<i>Non-Pairing Sublinear Verifiable Zero-Knowledge Arguments in Discrete Logarithm Setting</i>"</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Sep 27, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper won the special prize at "<b style="color:var(--cna-forest)">National Cryptographic Technology Contest, 2022</b>". Congrats <b>Sunpill Kim</b>, who was the lead author of this submission.
+          <ul>
+            <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b> "<i>Deep Face Template Protection in the Wild</i>"</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Sep 20, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          HUCC, Crypto Club of Hanyang University, won an award for excellence (우수상) in "<b style="color:var(--cna-forest)">Crypto Analysis Contest, 2022</b>", hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Sep 13, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Yunjeong Heo</b> (undergraduate student) joined our Cryptology &amp; Algorithm Lab!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Sep 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Hyunjung Son</b> (undergraduate student) joined our Cryptology &amp; Algorithm Lab!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Sep 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Hyeonbum Lee</b> and <b>Kyuhwan Lee</b> visit the Data Security and Privacy lab (led by Prof. Taeho Jung) in the CSE at the University of Notre Dame to collaborate with DSP-lab for six months. We wish them a successful journey to become good researchers!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Aug 25, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">ASIACRYPT</b> 2022.
+          <ul>
+            <li>Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b>, "<i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i>"</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Jul 11, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          A new project supported by CRYPTOLAB (Title : Development of Encrypted Face Template DB Search Technology) has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Jul 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Sangyoon Shin</b> (undergraduate student) joined in our Cryptology &amp; Algorithm Lab!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Jun 10, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted in <b style="color:var(--cna-indigo)">IEEE Blockchain</b>.
+          <ul>
+            <li><b>Chanyang Ju</b>, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung "<i>Monitoring Provenance of Delegated Personal Data With Blockchain</i>"</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">May 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Minsu Kim</b> (undergraduate student) and <b>Seongae Baik</b> (undergraduate student) joined in our Cryptology &amp; Algorithm Lab!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">May 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          A new project supported by Institute for Information and Communications Technology Promotion, IITP (Title: "Logging and Zero-knowledge Proof based on Hierarchical Blockchain") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Apr 18, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          The following paper has been accepted at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          <ul>
+            <li><b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b> "<i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger</i>" (<a href="https://ieeexplore.ieee.org/document/9758733">DOI</a>)</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Apr 1, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          A new project supported by National Security Research Institute, NSR (Title: "Research on the design technology of a cryptographic proof system suitable for Proof-Carrying Data") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">Feb 22, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          A new project supported by Korea Institute of Information Security &amp; Crytology, KIISC (Title: "A study on biometric information extraction threats and countermeasures in deep learning-based face recognition system") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Jan 3, 2022</time>
+        </header>
+        <div class="cna-card-body">
+          <b>Bora Jeong</b> (undergraduate student) and <b>Seunghun Paik</b> (undergraduate student) joined in our Cryptology &amp; Algorithm Lab!
+        </div>
+      </article>
+
+    </div>
+  </div>
 </details>
 
-<br>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2021</h3>
+    <span class="cna-year-count">10 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
 
-<details> 
-    <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Algorithm
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-l3ow{border-color:inherit;text-align:left;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Algorithm</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-3ow" colspan="5"><b>Every Wednesday at 1pm</b></td>
-      </tr>
-    </tbody>
-    </table>
-</details> 
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">Dec 8, 2021</time>
+        </header>
+        <div class="cna-card-body">
+          Our paper (<a href="https://ieeexplore.ieee.org/document/9638642">Efficient Sum-Check Protocol for Convolution</a>) is accepted at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+        </div>
+      </article>
 
-<br>
+      <article class="cna-card cna-cat-people">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-people">Member</span>
+          <time class="cna-card-meta">Nov 29, 2021</time>
+        </header>
+        <div class="cna-card-body">
+          Three undergraduate students (Kyuhwan Lee, Dongsoo Kim, Chanwoo Hwang) joined our Crypto &amp; Algorithms Lab!
+        </div>
+      </article>
 
-<details> 
-    <br>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Zero Knowledge Proof
-    </summary>
-    <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-l3ow{border-color:inherit;text-align:left;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px; margin-left: auto; margin-right: auto;">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Zero Knowledge Proof</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-3ow" colspan="5"><b>TBD</b></td>
-      </tr>
-    </tbody>
-    </table>
-</details>
-</details>
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Nov 26, 2021</time>
+        </header>
+        <div class="cna-card-body">
+          Taesam Kim (Undergraduate student) and Gyuhwan (Undergraduate student) receive a Top Prize from College of Natural Science (Hanyang University), due to their academic paper entitled "Proof of dot product using ZK-SNARK: Groth16" submitted in Academic Seminar. Congrat. Taesam and Gyuhwan!
+        </div>
+      </article>
 
-### Blog (<a href ="https://crypto-algorithm-lab.blogspot.com/" target = "_blank">Accessible link</a>)
-Note that the contents of the seminar will be shared through the following blog post.
-</details>
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Conference</span>
+          <time class="cna-card-meta">Nov 5, 2021</time>
+        </header>
+        <div class="cna-card-body">
+          Presentation of research results related to Ironmask at <a href="http://aiassociation.kr/Conference/ConferenceView.asp?AC=0&amp;CODE=CC20210801&amp;B_CATE=BBC1">2021 KAIC Fall Meeting</a>.
+        </div>
+      </article>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-            2022
-    </summary>
-    <ul type="square">
-    <li>
-        (Dec 10, 2022) The following paper has been accepted in <b>IEEE Access</b>
-        <ul type="disc">
-          <li>
-             <b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b>, "<i>Analysis on Secure Triplet Loss.</i>" (<A href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9965373">DOI</A>)
-          </li>  
-        </ul>
-    </li>
-    <li>
-        (Nov 11, 2022) <b>Bora Jeong</b> visits in the Singapore A*STAR to participate short-term research for top international students during four months. We wish her a successful journey to become good researchers!
-    </li>
-    <li>
-        (Sep 27, 2022) The following paper won the grand prize at "<b>National Cryptographic Technology Contest, 2022</b>".Congrats <b>Hyeonbum Lee</b>, who was the lead author of this submission.
-<ul type="circle">
-    <li> <b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b>, "<i>Non-Pairing Sublinear Verifiable Zero-Knowledge Arguments in Discrete Logarithm Setting"</i></li>
-    </ul>
-    </li>  
-    <li>
-        (Sep 27, 2022) The following paper won the special prize at "<b>National Cryptographic Technology Contest, 2022</b>". Congrats <b>Sunpill Kim</b>, who was the lead author of this submission.
-<ul type="circle">
-    <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b> "<i>Deep Face Template Protection in the Wild</i>"</li>
-    </ul>
-    </li>
-    <li>
-        (Sep 20, 2022) HUCC, Crypto Club of Hanyang University, won an award for excellence (우수상) in "<b>Crypto Analysis Contest, 2022</b>", hosted by Military Crypto Research Center. Congrats two of C&A members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
-    </li>
-    <li>
-        (Sep 13, 2022) <b>Yunjeong Heo</b> (undergraduate student) joined our Cryptology & Algorithm Lab!
-    </li>
-    <li>
-        (Sep 1, 2022) <b>Hyunjung Son</b> (undergraduate student) joined our Cryptology & Algorithm Lab!
-    </li>
-    <li>
-        (Sep 1, 2022) <b>Hyeonbum Lee</b> and <b>Kyuhwan Lee</b> visit the Data Security and Privacy lab (led by Prof. Taeho Jung) in the CSE at the University of Notre Dame to collaborate with DSP-lab for six months. We wish them a successful journey to become good researchers!
-    </li>
-    <li>
-        (Aug 25, 2022)  The following paper has been accepted for presentation at the <b>ASIACRYPT 2022</b>.
-      <ul type="disc">
-          <li>
-            Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b>, "<i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i>"
-          </li>  
-      </ul>
-    </li>  
-    <li>
-        (Jul 11, 2022) A new project supported by CRYPTOLAB (Title : Development of Encrypted Face Template DB Search Technology) has started.
-    </li> 
-    <li>
-        (Jul 1, 2022) <b>Sangyoon Shin</b> (undergraduate student) joined in our Cryptology & Algorithm Lab!
-    </li> 
-    <li>
-        (Jun 10, 2022) The following paper has been accepted in <b>IEEE Blockchain</b>.
-        <ul type="disc">
-        <li>
-            <b>Chanyang Ju</b>, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung "<i>Monitoring Provenance of Delegated Personal Data With Blockchain</i>"
-        </li>
-        </ul>  
-    </li>
-    <li>
-        (May 1, 2022) <b>Minsu Kim</b> (undergraduate student) and <b>Seongae Baik</b> (undergraduate student) joined in our Cryptology & Algorithm Lab!
-    </li>
-    <li>
-        (May 1, 2022) A new project supported by Institute for Information and Communications Technology Promotion, IITP (Title: "Logging and Zero-knowledge Proof based on Hierarchical Blockchain") has started.
-    </li>
-    <li>
-        (Apr 18, 2022)  The following paper has been accepted at <b>IEEE Access</b>.
-        <ul type="disc">
-        <li>
-            <b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b> "<i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger</i>" (<A href="https://ieeexplore.ieee.org/document/9758733">DOI</A>)
-        </li>
-        </ul>
-    </li>
-    <li>
-        (Apr 1, 2022) A new project supported by National Security Research Institute, NSR (Title: "Research on the design technology of a cryptographic proof system suitable for Proof-Carrying Data") has started.
-    </li>  
-    <li>
-        (Feb 22, 2022) A new project supported by Korea Institute of Information Security & Crytology, KIISC (Title: "A study on biometric information extraction threats and countermeasures in deep learning-based face recognition system") has started.
-    </li>
-    <li>
-        (Jan 3, 2022) <b>Bora Jeong</b> (undergraduate student) and <b>Seunghun Paik</b> (undergraduate student) joined in our Cryptology & Algorithm Lab!
-    </li>  
-    </ul>
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">Oct 1, 2021</time>
+        </header>
+        <div class="cna-card-body">
+          Hyeonbum Lee (MS&amp;Ph.D student) will receive a Special Prize from Korea Cryptography Forum, due to his paper entitled "Efficient Zero-Knowledge Argument in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier" submitted in National Cryptographic Technology Contest. Congrat. Hyeonbum!
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          A new project (Title: "Secure Multi-party Approximate Computation") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Conference</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          Presentation of research results related to Ironmask at <a href="https://research.samsung.com/sstf">SSTF 2021</a>.
+          <ul>
+            <li>
+              <details>
+                <summary>(For more information, click the arrow)</summary>
+                <iframe src="https://www.youtube.com/embed/RDl81Jd83zc?start=15563" width="560" height="315" frameborder="0"></iframe>
+              </details>
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          Seminar on "Secure Computation and Management for Large Scale Data Aggregation" by Prof. <a href="https://sites.nd.edu/taeho-jung/">Tae-Ho Jung</a>.
+          <ul>
+            <li>
+              <details>
+                <summary>(For more information, click the arrow)</summary>
+                <img src="{{ site.url }}{{ site.baseurl }}/assets/images/0001.jpg" style="width:50%; max-width:600px;">
+              </details>
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          A new project (Title: "Blockchain and Zero Knowledge Proof for Searchable and Privacy-preserving Provenance Logging") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          A new project (Title: "Study on Crypto Primitives for SNARK") has started.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-event">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-event">Grant</span>
+          <time class="cna-card-meta">2021</time>
+        </header>
+        <div class="cna-card-body">
+          A new project (Title: "Research on Incrementally Verifiable Computation Design Technique and Application Method") has started.
+        </div>
+      </article>
+
+    </div>
+  </div>
 </details>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-            2021
-    </summary>
-    <ul type="square">
-     <li>
-        (Dec 8, 2021) Our paper (<A href="https://ieeexplore.ieee.org/document/9638642">Efficient Sum-Check Protocol for Convolution</A>) is accepted at IEEE Access
-    </li>
-    <li>
-        (Nov 29, 2021) Three undergraduate students (Kyuhwan Lee, Dongsoo Kim, Chanwoo Hwang) joined our Crypto & Algorithms Lab!
-    </li>
-    <li>
-        (Nov 26, 2021) Taesam Kim (Undergraduate student) and Gyuhwan (Undergraduate student) receive a Top Prize from College of Natural Science (Hanyang University), due to their academic paper entitled "Proof of dot product using ZK-SNARK: Groth16" submitted in Academic Seminar. Congrat. Taesam and Gyuhwan!
-    </li>
-    <li>
-        (Nov 5, 2021) Presentation of research results related to Ironmask at <A href="http://aiassociation.kr/Conference/ConferenceView.asp?AC=0&CODE=CC20210801&B_CATE=BBC1">2021 KAIC Fall Meeting</A>
-    </li>
-    <li>
-        (Oct 1, 2021) Hyeonbum Lee (MS&Ph.D student) will receive a Special Prize from Korea Cryptography Forum, due to his paper entitled "Efficient Zero-Knowledge Argument in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier" submitted in National Cryptographic Technology Contest. Congrat. Hyeonbum!
-    </li>
-    <li>
-        A new project (Title: "Secure Multi-party Approximate Computation") has started.    
-    </li>
-    <li>
-        Presentation of research results related to Ironmask at <A href="https://research.samsung.com/sstf">SSTF 2021</A>
-        <details>
-            <summary>
-                (For more information, click the arrow)
-            </summary>
-            <iframe src="https://www.youtube.com/embed/RDl81Jd83zc?start=15563" width="560" height="315" frameborder="0"> </iframe>
-        </details>
-    </li>
-    <li>
-        Seminar on "Secure Computation and Management for Large Scale Data Aggregation" by Prof. <A href="https://sites.nd.edu/taeho-jung/">Tae-Ho Jung</A>
-        <details>
-            <summary>
-                (For more information, click the arrow)
-            </summary>
-            <img src="{{ site.url }}{{ site.baseurl }}/assets/images/0001.jpg">
-        </details>
-    </li>
-    <li>
-        A new project (Title: "Blockchain and Zero Knowledge Proof for Searchable and Privacy-preserving Provenance Logging") has started.    
-    </li>
-    <li>
-        A new project (Title: "Study on Crypto Primitives for SNARK") has started.    
-    </li>
-    <li>
-        A new project (Title: "Research on Incrementally Verifiable Computation Design Technique and Application Method") has started.    
-    </li>  
-    </ul>
-</details>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2020</h3>
+    <span class="cna-year-count">2 events</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-            2020
-    </summary>
-    <ul type="square">
-    <li>
-        Our paper (<A href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask: Modular Architecture for Protecting Deep Face Template</A>) is accepted at <A href="http://cvpr2021.thecvf.com/">CVPR 2021</A>
-    </li>
-    <li>
-        [<A href="https://eprint.iacr.org/2020/735">Bulletproofs+</A>] Participant Prizes (2020) in the National Cryptographic Technology Contest, National Intelligence Service, Korea.
-    </li>  
-    </ul>
+      <article class="cna-card cna-cat-paper">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-paper">Paper</span>
+          <time class="cna-card-meta">2020</time>
+        </header>
+        <div class="cna-card-body">
+          Our paper (<a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask: Modular Architecture for Protecting Deep Face Template</a>) is accepted at <a href="http://cvpr2021.thecvf.com/"><b style="color:var(--cna-indigo)">CVPR</b> 2021</a>.
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-award">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-award">Award</span>
+          <time class="cna-card-meta">2020</time>
+        </header>
+        <div class="cna-card-body">
+          [<a href="https://eprint.iacr.org/2020/735">Bulletproofs+</a>] Participant Prizes (2020) in the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, National Intelligence Service, Korea.
+        </div>
+      </article>
+
+    </div>
+  </div>
 </details>
 
 ## Previous Seminar
 
-<details open>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        2022
-    </summary>
-    <ol>
-    <details> 
-    <summary style="font-size:1rem; font-weight:bold;">
-        Deep Learning
-    </summary>
-        <style type="text/css">
-   .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 110px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Deep Learning Paper</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow" rowspan="3">1/7</td>
-        <td class="tg-c3ow" rowspan="3">10:00AM</td>
-        <td class="tg-c3ow" rowspan="3">701</td>
-        <td class="tg-c3ow" rowspan="3">Bora</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/1706.03762.pdf">Attention is All You Need</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2010.11929.pdf">An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2106.04803.pdf">CoAtNet: Marrying Convolution and Attention for All Data Sizes</A></td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow" rowspan="3">1/13</td>
-        <td class="tg-c3ow" rowspan="3">10:00AM</td>
-        <td class="tg-c3ow" rowspan="3">701</td>
-        <td class="tg-c3ow" rowspan="3">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/1911.01840.pdf">Who is Real Bob? Adversarial Attacks on Speaker Recognition Systems</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2106.14290.pdf">Darker than Black-Box: Face Reconstruction from Similarity Queries</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2104.02239.pdf">IronMask: Modular Architecture for Protecting Deep Face Template</A></td>
-      </tr> 
-      <tr>
-        <td class="tg-c3ow">1/20</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://thesai.org/Downloads/Volume12No4/Paper_36-PlexNet_An_Ensemble_of_Deep_Neural_Networks.pdf">PlexNet: An Ensemble of Deep Neural Networks for Biometric Template Protection</A></td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow">1/27</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow">Bora</td>
-        <td class="tg-c3ow"><A href="https://web.fe.up.pt/~jsc/publications/journals/2021JoaoPintoTBIOM.pdf">Secure Triplet Loss: Achieving Cancelability and Non-Linkability in End-to-End Deep Biometrics</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">2/3</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=9118594">Deep Index-of-Maximum Hashing for Face Template Protection</A></td>
-      </tr> 
-      <tr>
-        <td class="tg-c3ow">2/10</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://dl.acm.org/doi/pdf/10.1145/3442198">Secure Chaff-less Fuzzy Vault for Face Identification Systems</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/6</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2011.10650.pdf">Very Deep VAES Generalize Autogregressive Models and can outperform them on images</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/13</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Bora</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2108.01513.pdf">Sphereface2 : Binary Classification Is All You Need for Deep Face Recognition</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/20</td>
-        <td class="tg-c3ow">11:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Dongsoo</td>
-        <td class="tg-c3ow"><A href="https://openaccess.thecvf.com/content/CVPR2021/papers/Deng_Variational_Prototype_Learning_for_Deep_Face_Recognition_CVPR_2021_paper.pdf">Variational Prototype Learning for Deep Face Recognition</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/27</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Chanwoo</td>
-        <td class="tg-c3ow"><A href="https://openaccess.thecvf.com/content_CVPR_2019/papers/Cubuk_AutoAugment_Learning_Augmentation_Strategies_From_Data_CVPR_2019_paper.pdf">AutoAugment : Learning Augmentation Strategies from Data</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/3</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Sunpil</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2201.06945.pdf">It’s All in the Head : Representation Knowledge Distillation through Classifier Sharing</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/17</td>
-        <td class="tg-c3ow">10:00AM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Seunghun</td>
-        <td class="tg-c3ow"><A href="https://proceedings.neurips.cc/paper/2020/file/4c5bcfec8584af0d967f1ab10179ca4b-Paper.pdf">Denoising diffusion probabilistic models</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">9/16</td>
-        <td class="tg-c3ow">11:00AM</td>
-        <td class="tg-c3ow">751</td>
-        <td class="tg-c3ow">Bora</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2208.00214.pdf"> Towards Privacy-Preserving, Real-Time and Lossless Feature Matching</A></td>
-      </tr>
-    </tbody>
-    </table>  
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2023 · Summer</h3>
+    <span class="cna-year-count">3 series</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>IVC</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">6/27 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Nova : Recursive Zero Knowledge Arguments from Folding Schemes</b> (<a href="https://eprint.iacr.org/2021/370.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyeonbum Lee</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/6 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Nova : Recursive Zero Knowledge Arguments from Folding Schemes</b> (<a href="https://eprint.iacr.org/2021/370.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyeonbum Lee</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/11 · 19:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>SuperNova: Proving universal machine executions without universal circuits</b> (<a href="https://eprint.iacr.org/2022/1758.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyunjung Son</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/18 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Customizable constraint systems for succinct arguments</b> (<a href="https://eprint.iacr.org/2023/552.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Seongae Baek</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/25 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Customizable constraint systems for succinct arguments</b> (<a href="https://eprint.iacr.org/2023/552.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Seongae Baek</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/1 · 13:00</span>
+            <span class="cna-card-meta">751</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Hypernova : Recursive arguments for customizable constraint systems</b> (<a href="https://eprint.iacr.org/2023/573.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyeonbum Lee</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/8 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Hypernova : Recursive arguments for customizable constraint systems</b> (<a href="https://eprint.iacr.org/2023/573.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyeonbum Lee</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/14 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Protostar : Generic Efficient Accumulation/Folding for Special-sound Protocols</b> (<a href="https://eprint.iacr.org/2023/620.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyunjung Son</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Protostar : Generic Efficient Accumulation/Folding for Special-sound Protocols</b> (<a href="https://eprint.iacr.org/2023/620.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Hyunjung Son</span>
+          </div>
+        </article>
+
+      </div>
     </details>
-    </ol>
-   <ol>
-    <details>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Modern Cryptography
-    </summary>
-      <style type="text/css">
-   .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 110px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Modern Cryptography</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>      
-      <tr>
-        <td class="tg-c3ow">9/20</td>
-        <td class="tg-c3ow">05:30PM</td>
-        <td class="tg-c3ow">740</td>
-        <td class="tg-c3ow">Bora</td>
-        <td class="tg-c3ow">Ch.2 Perfectly Secret Encryption</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">9/27</td>
-        <td class="tg-c3ow">05:30PM</td>
-        <td class="tg-c3ow">740</td>
-        <td class="tg-c3ow">All Member</td>
-        <td class="tg-c3ow">Remaining Part of Ch.2 & Ch.2 Exercise</td>
-      </tr>      
-    </tbody>
-    </table>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Deep Learning</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>DeepFool: A simple and accurate method to fool deep neural networks (CVPR'16)</b> (<a href="https://arxiv.org/abs/1511.04599">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Bora Jeong</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Adversarial Examples Are Not Bugs, They Are Features (NIPS'19 Spotlight)</b> (<a href="https://arxiv.org/pdf/1905.02175.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Seunghun Paik</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/19 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Adversarial Patch (arXiv'17)</b> (<a href="https://arxiv.org/pdf/1905.02175.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Chanwoo Hwang</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/19 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Efficient Decision-based Black-box Adversarial Attacks on Face Recognition (CVPR'19)</b> (<a href="https://openaccess.thecvf.com/content_CVPR_2019/papers/Dong_Efficient_Decision-Based_Black-Box_Adversarial_Attacks_on_Face_Recognition_CVPR_2019_paper.pdf">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Dongsoo Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/26 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Universal adversarial perturbations (CVPR'17)</b> (<a href="https://arxiv.org/abs/1610.08401">DOI</a>)<br>
+            <span style="color:var(--cna-soft)">Minsu Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/2 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Iris Recognition</b> (<a href="https://drive.google.com/file/d/1vo1CsLA-qk4vnqp5Sn1JcrqgJMqAtlR2/view?usp=drive_link" target="_blank">Slides</a> · <a href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-iris-recognition-iriscode.html" target="_blank">Blog</a>)<br>
+            <span style="color:var(--cna-soft)">Bora Jeong</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/2 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Understanding Adversarial Examples</b> (<a href="https://drive.google.com/file/d/1XJoMJjMt2eLpl36BZhRNa0sR4pQu1ynu/view?usp=drive_link" target="_blank">Slides</a> · <a href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-adversarial-example-understanding.html" target="_blank">Blog</a>)<br>
+            <span style="color:var(--cna-soft)">Seunghun Paik</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/9 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>What is Dataset Distillation?</b> (<a href="https://drive.google.com/file/d/1S9kC57d5g-psBJxS7qVjYT_inM8xfgl-/view?usp=drive_link" target="_blank">Slides</a> · <a href="https://crypto-algorithm-lab.blogspot.com/2023/08/dl-dataset-distillation-dataset.html" target="_blank">Blog</a>)<br>
+            <span style="color:var(--cna-soft)">Chanwoo Hwang</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/16 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Predictive Coding</b><br>
+            <span style="color:var(--cna-soft)">Dongsoo Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/30 · 10:00</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Recurrent Neural Network</b><br>
+            <span style="color:var(--cna-soft)">Hyeonkyu Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">9/1 · 15:00</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Fuzzy Extractor</b><br>
+            <span style="color:var(--cna-soft)">Minsu Kim</span>
+          </div>
+        </article>
+
+      </div>
     </details>
-    </ol> 
-    <ol>
-    <details>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Proof-Carrying Data
-    </summary>
-      <style type="text/css">
-   .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 110px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Proof-Carrying Data</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>      
-      <tr>
-        <td class="tg-c3ow">6/30</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Hyeonbum</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1618.pdf">Proof-Carrying Data without Succinct Arguments</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/14</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">701</td>
-        <td class="tg-c3ow">Hyeonbum</td>
-        <td class="tg-c3ow">Research topic : sublinear decidable accumulator scheme</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/21</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Hyeonbum</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1618.pdf">Proof-Carrying Data without Succinct Arguments</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/8</td>
-        <td class="tg-c3ow">02:00PM</td>
-        <td class="tg-c3ow">702</td>
-        <td class="tg-c3ow">Hyeonbum</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1536.pdf">Halo Infinite : Proof-Carrying Data from Additive Polynomial Commitments</A></td>
-      </tr>
-    </tbody>
-    </table>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>ZKP Basic</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/07 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>proofs, interactive proofs, schwarz-zippel lemma, multilinear extension</b><br>
+            <span style="color:var(--cna-soft)">Junhee Cho</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/14 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>sumcheck protocol</b><br>
+            <span style="color:var(--cna-soft)">Yunki Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/21 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>application of sum-check protocol</b><br>
+            <span style="color:var(--cna-soft)">Seongae Baek</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/28 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>GKR protocol</b><br>
+            <span style="color:var(--cna-soft)">Seongae Baek</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/04 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>non-interactive proofs, random oracle model, fiat-shamir heuristic argument of knowledge, knowledge soundness</b><br>
+            <span style="color:var(--cna-soft)">Junhee Cho · Yunki Kim</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/10 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>zero-knowledge, sigma protocol</b><br>
+            <span style="color:var(--cna-soft)">Yunki Kim</span>
+          </div>
+        </article>
+
+      </div>
     </details>
-    </ol>   
-    <ol>
-    <details>
-    <summary style="font-size:1rem; font-weight:bold;">
-        Zero Knowledge Proof
-    </summary>
-      <style type="text/css">
-   .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:middle}
-    .tg .tg-5jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 70px">
-    <col style="width: 100px">
-    <col style="width: 77px">
-    <col style="width: 110px">
-    <col style="width: 640px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-5jts" colspan="5">Seminar Schedule - Zero Knowledge Proof</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Time</td>
-        <td class="tg-c3ow">Place</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>      
-      <tr>
-        <td class="tg-c3ow">7/5</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">740</td>
-        <td class="tg-c3ow">Kyuhwan</td>
-        <td class="tg-c3ow">F-S transformation</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/12</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">740</td>
-        <td class="tg-c3ow">Kyuhwan</td>
-        <td class="tg-c3ow">Front end : Program2circuit</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/19</td>
-        <td class="tg-c3ow">04:00PM</td>
-        <td class="tg-c3ow">740</td>
-        <td class="tg-c3ow">Kyuhwan</td>
-        <td class="tg-c3ow">Program2circuit Sumcheck</td>
-      </tr>
-    </tbody>
-    </table>
-    </details>
-    </ol>  
+
+    <p style="font-size:var(--cna-fs-sm); color:var(--cna-soft); margin-top:var(--cna-s-5);">
+      Blog (<a href="https://crypto-algorithm-lab.blogspot.com/" target="_blank">Accessible link</a>) — Note that the contents of the seminar will be shared through the following blog post.
+    </p>
+
+  </div>
 </details>
 
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022–2023 · Winter</h3>
+    <span class="cna-year-count">4 series</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        2021
-    </summary>
-        <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:top}
-    .tg .tg-7jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 82px">
-    <col style="width: 131px">
-    <col style="width: 72px">
-    <col style="width: 297px">
-    <col style="width: 131px">
-    <col style="width: 72px">
-    <col style="width: 297px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-7jts" colspan="7">Seminar Schedule</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Place(10:00 AM)</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-        <td class="tg-c3ow">Place(2:00 PM)</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/7</td>
-        <td class="tg-c3ow"><A href="https://zoom.us/j/91625915128#success">Zoom Link</A></td>
-        <td class="tg-c3ow">주찬양</td>
-        <td class="tg-c3ow"><A href="https://papers.nips.cc/paper/2017/file/6048ff4e8cb07aa60b6777b6f7384d52-Paper.pdf">SafetyNets</A></td>
-         <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">1/21</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김선필</td>
-        <td class="tg-c3ow"><A href="https://iacr.org/archive/tcc2008/49480001/49480001.pdf">Incrementally Verifiable Computation</A></td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow">1/28</td>
-        <td class="tg-c3ow"><A href="https://us02web.zoom.us/j/86870082959">Zoom Link</A></td>
-        <td class="tg-c3ow">이현범</td>
-        <td class="tg-c3ow">Inception</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow">2/4</td>
-        <td class="tg-c3ow"><A href="https://us02web.zoom.us/j/6830970476">Zoom Link</A></td>
-        <td class="tg-c3ow">정희원</td>
-        <td class="tg-c3ow">Privacy-preserving decentralized exchange</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>  
-      <tr>
-        <td class="tg-c3ow">7/2</td>
-        <td class="tg-c3ow">자연과학관 707호</td>
-        <td class="tg-c3ow">FR Team</td>
-        <td class="tg-c3ow">Face Recognition</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/12</td>
-        <td class="tg-c3ow"><A href="https://us02web.zoom.us/j/87310910372">Zoom Link</A></td>
-        <td class="tg-c3ow">FR Team</td>
-        <td class="tg-c3ow"><A href="https://openaccess.thecvf.com/content/CVPR2021/papers/Meng_MagFace_A_Universal_Representation_for_Face_Recognition_and_Quality_Assessment_CVPR_2021_paper.pdf">MagFace: A Universal Representation for Face Recognition and Quality Assessment</A></td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr> 
-      <tr>
-        <td class="tg-c3ow">7/16</td>
-        <td class="tg-c3ow"><A href="https://us02web.zoom.us/j/87310910372">Zoom Link</A></td>
-        <td class="tg-c3ow">FR Team</td>
-        <td class="tg-c3ow"><A href="https://arxiv.org/pdf/2010.05222.pdf">Partial FC: Training 10 Million Identities on a Single Machine</A></td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr> 
-    </tbody>
-    </table>      
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Deep Learning</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/2 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2202.04557.pdf">Universal Hopfield Networks: A General Framework for Single-Shot Associative Memory Models</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/2 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://openaccess.thecvf.com/content/ICCV2021/papers/Yang_Towards_Face_Encryption_by_Generating_Adversarial_Identity_Masks_ICCV_2021_paper.pdf">Towards Face Encryption by Generating Adversarial Identity Masks</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/16 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2205.12010.pdf">SFace: Sigmoid-Constrained Hypersphere Loss for Robust Face Recognition</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/16 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2207.10131.pdf">Continual variational autoencoder learning via online cooperative memorization</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/26 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Hopfield Network Summary</b><br>
+            <span style="color:var(--cna-soft)">Prof. Jaehong Seo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/30 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://aaai-2022.virtualchair.net/poster_aaai88">AnchorFace: Boosting TAR@FAR for Practical Face Recognition</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/30 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2207.07316.pdf">Privacy-Preserving Face Recognition with Learnable Privacy Budgets in Frequency Domain</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/13 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://openaccess.thecvf.com/content/CVPR2022/html/Tan_Hyperspherical_Consistency_Regularization_CVPR_2022_paper.html">Hyperspherical Consistency Regularization</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/13 · 13:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/abs/2204.05502">CoupleFace: Relation Matters for Face Recognition Distillation</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/20 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9955645">QuantFace: Towards lightweight face recognition by synthetic data low-bit quantization</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/20 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2210.08013.pdf">On the Relationship Between Variational Inference and Auto-Associative Memory</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://www.mdpi.com/2079-9292/11/23/3909">UFace: An Unsupervised Deep Learning Face Verification System</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9796565">Frontal-Centers Guided Face: Boosting Face Recognition by Learning Pose-Invariant Features</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Computational Number Theory &amp; Algebra</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+        <p style="font-size:var(--cna-fs-sm); color:var(--cna-soft); margin:0 0 var(--cna-s-3);">
+          Textbook: <b>A Computational Introduction to Number Theory and Algebra</b>, Second Edition.
+        </p>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/5 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 1 ~ 4, Review on Number Theory and Integer Arithmetics</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/12 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 8 ~ 9, Probabilistic Distributions and Algorithms on <img src="https://latex.codecogs.com/svg.image?\inline&space;\mathbb{Z}_p" title="https://latex.codecogs.com/svg.image?\inline \mathbb{Z}_p" /></b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/19 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 10 ~ 12, More Probabilistic Algorithms on <img src="https://latex.codecogs.com/svg.image?\inline&space;\mathbb{Z}_p" title="https://latex.codecogs.com/svg.image?\inline \mathbb{Z}_p" /> (e.g. Miller-Rabin Test)</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/26 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 6, 7, 13, 14, Groups, Rings, Modules, and Vector Spaces</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/2 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 16, More on Rings (e.g. Field Extension, PID, UFD, ...)</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/9 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 17 ~ 18, Polynomial Arithmetics, and Linearly Generated Sequences</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/16 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 19 ~ 20, Finite Fields, Algorithms for Finite Fields (e.g. Cantor-Zassenhaus Algorithm)</b>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/23 · 13:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Chap. 15, 21, Dixon's Method, Index Calculus Method, and AKS Algorithm</b>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Algorithm</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">Every Wed · 13:00</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Algorithm Seminar Series</b>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Zero Knowledge Proof</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-card-meta">TBA</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Zero Knowledge Proof Seminar Series</b>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+  </div>
 </details>
 
-<details>
-    <summary style="font-size:1.2rem; font-weight:bold;">
-        2020
-    </summary>
-        <style type="text/css">
-    .tg  {border-collapse:collapse;border-color:#93a1a1;border-spacing:0;}
-    .tg td{background-color:#fdf6e3;border-color:#93a1a1;border-style:solid;border-width:1px;color:#002b36;
-      font-family:Arial, sans-serif;font-size:14px;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg th{background-color:#657b83;border-color:#93a1a1;border-style:solid;border-width:1px;color:#fdf6e3;
-      font-family:Arial, sans-serif;font-size:14px;font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
-    .tg .tg-c3ow{border-color:inherit;text-align:center;vertical-align:top}
-    .tg .tg-7jts{border-color:inherit;font-size:18px;text-align:center;vertical-align:top}
-    </style>
-    <table class="tg" style="undefined;table-layout: fixed; width: 1082px">
-    <colgroup>
-    <col style="width: 82px">
-    <col style="width: 131px">
-    <col style="width: 72px">
-    <col style="width: 297px">
-    <col style="width: 131px">
-    <col style="width: 72px">
-    <col style="width: 297px">
-    </colgroup>
-    <thead>
-      <tr>
-        <th class="tg-7jts" colspan="7">Seminar Schedule</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="tg-c3ow">Date</td>
-        <td class="tg-c3ow">Place(10:00 AM)</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-        <td class="tg-c3ow">Place(2:00 PM)</td>
-        <td class="tg-c3ow">Presenter</td>
-        <td class="tg-c3ow">Topic</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">6/25/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">정희원</td>
-          <td class="tg-c3ow"><A href="https://scalingbitcoin.org/papers/mimblewimble.pdf">Mimblewimble</A> &amp; <A href="https://eprint.iacr.org/2019/191.pdf">Zether</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/9/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김선필</td>
-        <td class="tg-c3ow">zkRollup</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">주찬양</td>
-          <td class="tg-c3ow"><A href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.217.4200&rep=rep1&type=pdf">GKR</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/16/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김동영</td>
-          <td class="tg-c3ow">Interoperability(<A href="https://eprint.iacr.org/2020/433.pdf">zkrelay)</A></td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">이현범</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/099.pdf">Sonic</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/23/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김동영</td>
-          <td class="tg-c3ow">Interoperability(<A href="https://eprint.iacr.org/2018/1239.pdf">Proof-of-Stake Sidechains</A>)</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">정희원</td>
-          <td class="tg-c3ow">Interoperability (<A href="https://arxiv.org/pdf/2002.01847.pdf">Zendoo</A>+alpha)</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">7/30/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">서재홍</td>
-        <td class="tg-c3ow">Inception</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/6/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김동우</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/142.pdf">LegoSNARK</A></td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">이현범</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/1229.pdf">Supersonic</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">8/13/2020</td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김지승</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2018/601.pdf">VDF</A></td>
-        <td class="tg-c3ow">자연과학관 702호</td>
-        <td class="tg-c3ow">김선필</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/953.pdf">Plonk</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">10/19/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">주찬양</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/1482.pdf">Virgo</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">10/26/2020</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">손용하</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2018/1188.pdf">Accumulator</A></td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">김창진</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2016/260.pdf">Groth16</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">11/5/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 746호</td>
-        <td class="tg-c3ow">김창진</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2016/260.pdf">Groth16</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">11/9/2020</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">김선필</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2019/1177.pdf">Inner Pairing Product</A></td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">이현범</td>
-          <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1274.pdf">Dory</A> &amp; <A href="https://eprint.iacr.org/2020/1275.pdf">Kopis</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">11/16/2020</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">이현범</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1274.pdf">Dory</A> &amp; <A href="https://eprint.iacr.org/2020/1275.pdf">Kopis</A></td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">김동우</td>
-        <td class="tg-c3ow">Verifiable Computation on Encrypted Data</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">11/19/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">김지승</td>
-        <td class="tg-c3ow">Cryptanalysis of LPN</td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">12/10/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">김선필</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1274.pdf">Dory</A></td>
-      </tr>
-      <tr>
-        <td class="tg-c3ow">12/24/2020</td>
-        <td class="tg-c3ow"></td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">N/A</td>
-        <td class="tg-c3ow">자연과학관 751호</td>
-        <td class="tg-c3ow">서재홍</td>
-        <td class="tg-c3ow"><A href="https://eprint.iacr.org/2020/1274.pdf">Dory</A> &amp; Inception</td>
-      </tr>  
-    </tbody>
-    </table>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022</h3>
+    <span class="cna-year-count">4 series</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Deep Learning</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/1706.03762.pdf">Attention is All You Need</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2010.11929.pdf">An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2106.04803.pdf">CoAtNet: Marrying Convolution and Attention for All Data Sizes</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/1911.01840.pdf">Who is Real Bob? Adversarial Attacks on Speaker Recognition Systems</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2106.14290.pdf">Darker than Black-Box: Face Reconstruction from Similarity Queries</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2104.02239.pdf">IronMask: Modular Architecture for Protecting Deep Face Template</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/20 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://thesai.org/Downloads/Volume12No4/Paper_36-PlexNet_An_Ensemble_of_Deep_Neural_Networks.pdf">PlexNet: An Ensemble of Deep Neural Networks for Biometric Template Protection</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">1/27 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://web.fe.up.pt/~jsc/publications/journals/2021JoaoPintoTBIOM.pdf">Secure Triplet Loss: Achieving Cancelability and Non-Linkability in End-to-End Deep Biometrics</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/3 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9118594">Deep Index-of-Maximum Hashing for Face Template Protection</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">2/10 · 10:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://dl.acm.org/doi/pdf/10.1145/3442198">Secure Chaff-less Fuzzy Vault for Face Identification Systems</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/6 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2011.10650.pdf">Very Deep VAES Generalize Autogregressive Models and can outperform them on images</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/13 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2108.01513.pdf">Sphereface2 : Binary Classification Is All You Need for Deep Face Recognition</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/20 · 11:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://openaccess.thecvf.com/content/CVPR2021/papers/Deng_Variational_Prototype_Learning_for_Deep_Face_Recognition_CVPR_2021_paper.pdf">Variational Prototype Learning for Deep Face Recognition</a></b><br>
+            <span style="color:var(--cna-soft)">Dongsoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/27 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://openaccess.thecvf.com/content_CVPR_2019/papers/Cubuk_AutoAugment_Learning_Augmentation_Strategies_From_Data_CVPR_2019_paper.pdf">AutoAugment : Learning Augmentation Strategies from Data</a></b><br>
+            <span style="color:var(--cna-soft)">Chanwoo</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/3 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2201.06945.pdf">It's All in the Head : Representation Knowledge Distillation through Classifier Sharing</a></b><br>
+            <span style="color:var(--cna-soft)">Sunpil</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/17 · 10:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://proceedings.neurips.cc/paper/2020/file/4c5bcfec8584af0d967f1ab10179ca4b-Paper.pdf">Denoising diffusion probabilistic models</a></b><br>
+            <span style="color:var(--cna-soft)">Seunghun</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">9/16 · 11:00</span>
+            <span class="cna-card-meta">751</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://arxiv.org/pdf/2208.00214.pdf">Towards Privacy-Preserving, Real-Time and Lossless Feature Matching</a></b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Modern Cryptography</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">9/20 · 17:30</span>
+            <span class="cna-card-meta">740</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Ch.2 Perfectly Secret Encryption</b><br>
+            <span style="color:var(--cna-soft)">Bora</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">9/27 · 17:30</span>
+            <span class="cna-card-meta">740</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Remaining Part of Ch.2 &amp; Ch.2 Exercise</b><br>
+            <span style="color:var(--cna-soft)">All Member</span>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Proof-Carrying Data</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">6/30 · 16:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://eprint.iacr.org/2020/1618.pdf">Proof-Carrying Data without Succinct Arguments</a></b><br>
+            <span style="color:var(--cna-soft)">Hyeonbum</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/14 · 16:00</span>
+            <span class="cna-card-meta">701</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Research topic : sublinear decidable accumulator scheme</b><br>
+            <span style="color:var(--cna-soft)">Hyeonbum</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/21 · 16:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://eprint.iacr.org/2020/1618.pdf">Proof-Carrying Data without Succinct Arguments</a></b><br>
+            <span style="color:var(--cna-soft)">Hyeonbum</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">8/8 · 14:00</span>
+            <span class="cna-card-meta">702</span>
+          </header>
+          <div class="cna-card-body">
+            <b><a href="https://eprint.iacr.org/2020/1536.pdf">Halo Infinite : Proof-Carrying Data from Additive Polynomial Commitments</a></b><br>
+            <span style="color:var(--cna-soft)">Hyeonbum</span>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+    <details markdown="0" style="margin-bottom:var(--cna-s-5);">
+      <summary><b>Zero Knowledge Proof</b></summary>
+      <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/5 · 16:00</span>
+            <span class="cna-card-meta">740</span>
+          </header>
+          <div class="cna-card-body">
+            <b>F-S transformation</b><br>
+            <span style="color:var(--cna-soft)">Kyuhwan</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/12 · 16:00</span>
+            <span class="cna-card-meta">740</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Front end : Program2circuit</b><br>
+            <span style="color:var(--cna-soft)">Kyuhwan</span>
+          </div>
+        </article>
+
+        <article class="cna-card cna-cat-talk">
+          <header class="cna-card-head">
+            <span class="cna-chip cna-chip-talk">7/19 · 16:00</span>
+            <span class="cna-card-meta">740</span>
+          </header>
+          <div class="cna-card-body">
+            <b>Program2circuit Sumcheck</b><br>
+            <span style="color:var(--cna-soft)">Kyuhwan</span>
+          </div>
+        </article>
+
+      </div>
+    </details>
+
+  </div>
 </details>
-        
 
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2021</h3>
+    <span class="cna-year-count">7 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+          <a class="cna-card-meta" href="https://zoom.us/j/91625915128#success">Zoom ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://papers.nips.cc/paper/2017/file/6048ff4e8cb07aa60b6777b6f7384d52-Paper.pdf">SafetyNets</a></b><br>
+          <span style="color:var(--cna-soft)">주찬양</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">1/21 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://iacr.org/archive/tcc2008/49480001/49480001.pdf">Incrementally Verifiable Computation</a></b><br>
+          <span style="color:var(--cna-soft)">김선필</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">1/28 · 10:00</span>
+          <a class="cna-card-meta" href="https://us02web.zoom.us/j/86870082959">Zoom ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Inception</b><br>
+          <span style="color:var(--cna-soft)">이현범</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">2/4 · 10:00</span>
+          <a class="cna-card-meta" href="https://us02web.zoom.us/j/6830970476">Zoom ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Privacy-preserving decentralized exchange</b><br>
+          <span style="color:var(--cna-soft)">정희원</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/2 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 707호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Face Recognition</b><br>
+          <span style="color:var(--cna-soft)">FR Team</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+          <a class="cna-card-meta" href="https://us02web.zoom.us/j/87310910372">Zoom ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://openaccess.thecvf.com/content/CVPR2021/papers/Meng_MagFace_A_Universal_Representation_for_Face_Recognition_and_Quality_Assessment_CVPR_2021_paper.pdf">MagFace: A Universal Representation for Face Recognition and Quality Assessment</a></b><br>
+          <span style="color:var(--cna-soft)">FR Team</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/16 · 10:00</span>
+          <a class="cna-card-meta" href="https://us02web.zoom.us/j/87310910372">Zoom ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://arxiv.org/pdf/2010.05222.pdf">Partial FC: Training 10 Million Identities on a Single Machine</a></b><br>
+          <span style="color:var(--cna-soft)">FR Team</span>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2020</h3>
+    <span class="cna-year-count">15 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">6/25/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://scalingbitcoin.org/papers/mimblewimble.pdf">Mimblewimble</a> &amp; <a href="https://eprint.iacr.org/2019/191.pdf">Zether</a></b><br>
+          <span style="color:var(--cna-soft)">정희원</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/9/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>zkRollup</b><br>
+          <span style="color:var(--cna-soft)">김선필</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/9/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.217.4200&amp;rep=rep1&amp;type=pdf">GKR</a></b><br>
+          <span style="color:var(--cna-soft)">주찬양</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/16/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Interoperability (<a href="https://eprint.iacr.org/2020/433.pdf">zkrelay</a>)</b><br>
+          <span style="color:var(--cna-soft)">김동영</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/16/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/099.pdf">Sonic</a></b><br>
+          <span style="color:var(--cna-soft)">이현범</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/23/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Interoperability (<a href="https://eprint.iacr.org/2018/1239.pdf">Proof-of-Stake Sidechains</a>)</b><br>
+          <span style="color:var(--cna-soft)">김동영</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/23/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Interoperability (<a href="https://arxiv.org/pdf/2002.01847.pdf">Zendoo</a> + alpha)</b><br>
+          <span style="color:var(--cna-soft)">정희원</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">7/30/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Inception</b><br>
+          <span style="color:var(--cna-soft)">서재홍</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">8/6/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/142.pdf">LegoSNARK</a></b><br>
+          <span style="color:var(--cna-soft)">김동우</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">8/6/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/1229.pdf">Supersonic</a></b><br>
+          <span style="color:var(--cna-soft)">이현범</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">8/13/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2018/601.pdf">VDF</a></b><br>
+          <span style="color:var(--cna-soft)">김지승</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">8/13/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 702호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/953.pdf">Plonk</a></b><br>
+          <span style="color:var(--cna-soft)">김선필</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">10/19/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/1482.pdf">Virgo</a></b><br>
+          <span style="color:var(--cna-soft)">주찬양</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">10/26/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2018/1188.pdf">Accumulator</a></b><br>
+          <span style="color:var(--cna-soft)">손용하</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">10/26/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2016/260.pdf">Groth16</a></b><br>
+          <span style="color:var(--cna-soft)">김창진</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/5/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 746호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2016/260.pdf">Groth16</a></b><br>
+          <span style="color:var(--cna-soft)">김창진</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/9/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2019/1177.pdf">Inner Pairing Product</a></b><br>
+          <span style="color:var(--cna-soft)">김선필</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/9/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2020/1274.pdf">Dory</a> &amp; <a href="https://eprint.iacr.org/2020/1275.pdf">Kopis</a></b><br>
+          <span style="color:var(--cna-soft)">이현범</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/16/2020 · 10:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2020/1274.pdf">Dory</a> &amp; <a href="https://eprint.iacr.org/2020/1275.pdf">Kopis</a></b><br>
+          <span style="color:var(--cna-soft)">이현범</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/16/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Verifiable Computation on Encrypted Data</b><br>
+          <span style="color:var(--cna-soft)">김동우</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">11/19/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Cryptanalysis of LPN</b><br>
+          <span style="color:var(--cna-soft)">김지승</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">12/10/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2020/1274.pdf">Dory</a></b><br>
+          <span style="color:var(--cna-soft)">김선필</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">12/24/2020 · 14:00</span>
+          <span class="cna-card-meta">자연과학관 751호</span>
+        </header>
+        <div class="cna-card-body">
+          <b><a href="https://eprint.iacr.org/2020/1274.pdf">Dory</a> &amp; Inception</b><br>
+          <span style="color:var(--cna-soft)">서재홍</span>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</details>

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -29,7 +29,7 @@ header:
           <time class="cna-card-meta">Dec 22, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          The following paper has been accepted for publication at <b>IEEE Access</b>.
           <ul>
             <li><b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo</b><br><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i></li>
           </ul>
@@ -42,7 +42,7 @@ header:
           <time class="cna-card-meta">Dec 03, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE T-BIOM</b>.
+          The following paper has been accepted for publication at <b>IEEE T-BIOM</b>.
           <ul>
             <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i></li>
           </ul>
@@ -55,7 +55,7 @@ header:
           <time class="cna-card-meta">Nov 20, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ASIACCS</b> 2026.
+          The following paper has been accepted for presentation at <b>ASIACCS</b> 2026.
           <ul>
             <li><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>Scalable Private Set Intersection over Distributed Encrypted Data</i></li>
           </ul>
@@ -68,7 +68,7 @@ header:
           <time class="cna-card-meta">Nov 15, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE TDSC</b>.
+          The following paper has been accepted for publication at <b>IEEE TDSC</b>.
           <ul>
             <li><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i></li>
           </ul>
@@ -81,7 +81,7 @@ header:
           <time class="cna-card-meta">Oct 23, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">NDSS</b> 2026.
+          The following paper has been accepted for presentation at <b>NDSS</b> 2026.
           <ul>
             <li>Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung<br><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i></li>
           </ul>
@@ -109,7 +109,7 @@ header:
           <time class="cna-card-meta">Sep 23, 2025</time>
         </header>
         <div class="cna-card-body">
-          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2025.
+          Papers led by C&amp;A members won several awards at the <b>National Cryptographic Technology Contest</b>, 2025.
           <ul>
             <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
               <ul>
@@ -132,7 +132,7 @@ header:
           <time class="cna-card-meta">Sep 19, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">NeurIPS</b> 2025.
+          The following paper has been accepted for presentation at <b>NeurIPS</b> 2025.
           <ul>
             <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b><br><i>Non-Adaptive Adversarial Face Generation</i></li>
           </ul>
@@ -145,7 +145,7 @@ header:
           <time class="cna-card-meta">Sep 07, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following 2 papers have been accepted for presentation at <b style="color:var(--cna-indigo)">IEEE ICTC</b> 2025.
+          The following 2 papers have been accepted for presentation at <b>IEEE ICTC</b> 2025.
           <ul>
             <li><b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>A Survey of Model Inversion Attacks on Image Domain</i></li>
             <li><b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>A Survey on Fuzzy Private Set Intersection Protocols</i></li>
@@ -159,7 +159,7 @@ header:
           <time class="cna-card-meta">Aug 28, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following 2 projects supported by the <b style="color:var(--cna-amber)">National Research Foundation of Korea (NRF)</b> have started.
+          The following 2 projects supported by the <b>National Research Foundation of Korea (NRF)</b> have started.
           <ul>
             <li><i>Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems</i></li>
             <li><i>A Study of Fuzzy Private Set Intersection</i></li>
@@ -173,7 +173,7 @@ header:
           <time class="cna-card-meta">Aug 4, 2025</time>
         </header>
         <div class="cna-card-body">
-          <b>Seunghun Paik</b> has been invited to give a poster presentation at the <b style="color:var(--cna-indigo)">KCCV</b> 2025.
+          <b>Seunghun Paik</b> has been invited to give a poster presentation at the <b>KCCV</b> 2025.
           <ul>
             <li>Date &amp; Place : 02:30 PM, Aug 6 / BEXCO, Busan, Korea</li>
             <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i></li>
@@ -207,7 +207,7 @@ header:
           <time class="cna-card-meta">Jun 26, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ICCV</b> 2025.
+          The following paper has been accepted for presentation at <b>ICCV</b> 2025.
           <ul>
             <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b><br><i>IDFace: Face Template Protection for Efficient and Secure Identification</i></li>
           </ul>
@@ -220,7 +220,7 @@ header:
           <time class="cna-card-meta">Jun 22, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ESORICS</b> 2025.
+          The following paper has been accepted for presentation at <b>ESORICS</b> 2025.
           <ul>
             <li>Jaehwan Park, <b>Hyeonbum Lee</b>, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim<br><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i></li>
           </ul>
@@ -267,7 +267,7 @@ header:
           <time class="cna-card-meta">Feb 27, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following project supported by the <b style="color:var(--cna-amber)">Korea Institute of Information Security &amp; Cryptology (KIISC)</b> has started.
+          The following project supported by the <b>Korea Institute of Information Security &amp; Cryptology (KIISC)</b> has started.
           <ul>
             <li><i>Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs</i></li>
           </ul>
@@ -290,7 +290,7 @@ header:
           <time class="cna-card-meta">Jan 1, 2025</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">Pattern Recognition</b>.
+          The following paper has been accepted for publication at <b>Pattern Recognition</b>.
           <ul>
             <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b><br><i>Deep Face Template Protection in the Wild</i></li>
           </ul>
@@ -336,7 +336,7 @@ header:
           <time class="cna-card-meta">Oct 11, 2024</time>
         </header>
         <div class="cna-card-body">
-          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2024.
+          Papers led by C&amp;A members won several awards at the <b>National Cryptographic Technology Contest</b>, 2024.
           <ul>
             <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
               <ul>
@@ -358,7 +358,7 @@ header:
           <time class="cna-card-meta">Oct 1, 2024</time>
         </header>
         <div class="cna-card-body">
-          HUCC, Crypto Club of Hanyang University, won the Encouragement Award (장려상) in <b style="color:var(--cna-forest)">Cryptanalysis Contest</b>, 2024, hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Yunki Kim</b>, and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
+          HUCC, Crypto Club of Hanyang University, won the Encouragement Award (장려상) in <b>Cryptanalysis Contest</b>, 2024, hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Yunki Kim</b>, and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
         </div>
       </article>
 
@@ -368,7 +368,7 @@ header:
           <time class="cna-card-meta">Jul 1, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">ECCV</b> 2024.
+          The following paper has been accepted for presentation at <b>ECCV</b> 2024.
           <ul>
             <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>Towards Certifiably Robust Face Recognition</i></li>
           </ul>
@@ -381,7 +381,7 @@ header:
           <time class="cna-card-meta">Jun 24, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following 2 projects supported by <b style="color:var(--cna-amber)">National Research Foundation of Korea (NRF)</b> have started.
+          The following 2 projects supported by <b>National Research Foundation of Korea (NRF)</b> have started.
           <ul>
             <li><i>Secure Authentication System using Deep Learning-based Biometric Recognition System</i></li>
             <li><i>A Study on Incremetally Verifiable Computation through Zero-Knowledge Proof</i></li>
@@ -395,7 +395,7 @@ header:
           <time class="cna-card-meta">Jun 7, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at <b style="color:var(--cna-indigo)">CISC-S</b> 2024. Also, this paper won the Excellenct Paper Award.
+          The following paper has been accepted for presentation at <b>CISC-S</b> 2024. Also, this paper won the Excellenct Paper Award.
           <ul>
             <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b><br><i>On the Certifiable Robustness of Face Recognition Systems</i></li>
           </ul>
@@ -428,7 +428,7 @@ header:
           <time class="cna-card-meta">Apr 19, 2024</time>
         </header>
         <div class="cna-card-body">
-          <b>Hyeonbum Lee</b> has been selected as a speaker for the submission proposal in the 6th <b style="color:var(--cna-indigo)">ZKProof workshop</b> in Berlin.
+          <b>Hyeonbum Lee</b> has been selected as a speaker for the submission proposal in the 6th <b>ZKProof workshop</b> in Berlin.
         </div>
       </article>
 
@@ -448,7 +448,7 @@ header:
           <time class="cna-card-meta">Apr 1, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following project supported by <b style="color:var(--cna-amber)">Korea Creative Content Agency (KOCCA)</b> has started.
+          The following project supported by <b>Korea Creative Content Agency (KOCCA)</b> has started.
           <ul>
             <li><i>International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology</i></li>
           </ul>
@@ -461,7 +461,7 @@ header:
           <time class="cna-card-meta">Mar 1, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted as a poster at <b style="color:var(--cna-indigo)">IEEE ICBC</b> 2024.
+          The following paper has been accepted as a poster at <b>IEEE ICBC</b> 2024.
           <ul>
             <li><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung<br><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></li>
           </ul>
@@ -484,7 +484,7 @@ header:
           <time class="cna-card-meta">Feb 5, 2024</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication at <b style="color:var(--cna-crimson)">IEEE TDSC</b>.
+          The following paper has been accepted for publication at <b>IEEE TDSC</b>.
           <ul>
             <li>Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung<br><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i></li>
           </ul>
@@ -510,7 +510,7 @@ header:
           <time class="cna-card-meta">Oct 29, 2023</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">IEEE S&amp;P</b> 2024.
+          The following paper has been accepted for presentation at the <b>IEEE S&amp;P</b> 2024.
           <ul>
             <li><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b><br><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></li>
           </ul>
@@ -523,7 +523,7 @@ header:
           <time class="cna-card-meta">Oct 4, 2023</time>
         </header>
         <div class="cna-card-body">
-          Papers led by C&amp;A members won several awards at the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, 2023.
+          Papers led by C&amp;A members won several awards at the <b>National Cryptographic Technology Contest</b>, 2023.
           <ul>
             <li>The following paper won the Excellence Award. Congrats all authors who participated in this submission.
               <ul>
@@ -550,7 +550,7 @@ header:
           <time class="cna-card-meta">Sep 26, 2023</time>
         </header>
         <div class="cna-card-body">
-          HUCC, Crypto Club of Hanyang University, won the Top Excellence Award (최우수상) in <b style="color:var(--cna-forest)">Cryptanalysis Contest</b>, 2023, hosted by Military Crypto Research Center. Congrats three of C&amp;A members, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, and <b>Minsu Kim</b>, who are a leader and two members of HUCC.
+          HUCC, Crypto Club of Hanyang University, won the Top Excellence Award (최우수상) in <b>Cryptanalysis Contest</b>, 2023, hosted by Military Crypto Research Center. Congrats three of C&amp;A members, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, and <b>Minsu Kim</b>, who are a leader and two members of HUCC.
         </div>
       </article>
 
@@ -560,7 +560,7 @@ header:
           <time class="cna-card-meta">Aug 22, 2023</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">BMVC</b> 2023 <b>(Oral)</b>.
+          The following paper has been accepted for presentation at the <b>BMVC</b> 2023 <b>(Oral)</b>.
           <ul>
             <li><b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b><br><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes</i></li>
           </ul>
@@ -573,7 +573,7 @@ header:
           <time class="cna-card-meta">Jul 25, 2023</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication in <b style="color:var(--cna-crimson)">IEEE TIFS</b>.
+          The following paper has been accepted for publication in <b>IEEE TIFS</b>.
           <ul>
             <li>Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo</b><br><i>Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption</i></li>
           </ul>
@@ -606,7 +606,7 @@ header:
           <time class="cna-card-meta">May 31, 2023</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication in <b style="color:var(--cna-indigo)">IWSEC</b> 2023.
+          The following paper has been accepted for publication in <b>IWSEC</b> 2023.
           <ul>
             <li><b>Hyeonbum Lee</b> and <b>Jae Hong Seo</b><br><i>TENET : Sublogarithmic Proof, Sublinear Verifier Inner Product Argument without a Trusted Setup</i></li>
           </ul>
@@ -629,7 +629,7 @@ header:
           <time class="cna-card-meta">Apr 20, 2023</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for publication in <b style="color:var(--cna-crimson)">Designs, Codes and Cryptography</b>.
+          The following paper has been accepted for publication in <b>Designs, Codes and Cryptography</b>.
           <ul>
             <li>Hyung Tae Lee and <b>Jae Hong Seo</b><br><i>On the Security of Functional Encryption in the Generic Group Model</i></li>
           </ul>
@@ -642,7 +642,7 @@ header:
           <time class="cna-card-meta">Apr 20, 2023</time>
         </header>
         <div class="cna-card-body">
-          Prof. <b>Jae Hong Seo</b> joins in the program committees of <b style="color:var(--cna-indigo)">ASIACRYPT</b> 2023 and <b style="color:var(--cna-indigo)">PQCrypto</b> 2023.
+          Prof. <b>Jae Hong Seo</b> joins in the program committees of <b>ASIACRYPT</b> 2023 and <b>PQCrypto</b> 2023.
         </div>
       </article>
 
@@ -652,7 +652,7 @@ header:
           <time class="cna-card-meta">Feb 14, 2023</time>
         </header>
         <div class="cna-card-body">
-          <b>Bora Jeong</b> won the Grand Prize in the <b style="color:var(--cna-forest)">Best Research Paper Award</b> for graduate students by the Research Institute for Natural Sciences, Hanyang University.
+          <b>Bora Jeong</b> won the Grand Prize in the <b>Best Research Paper Award</b> for graduate students by the Research Institute for Natural Sciences, Hanyang University.
           <ul>
             <li><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo</b><br><i>Analysis on Secure Triplet Loss.</i></li>
           </ul>
@@ -688,7 +688,7 @@ header:
           <time class="cna-card-meta">Dec 10, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted in <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          The following paper has been accepted in <b>IEEE Access</b>.
           <ul>
             <li><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b>, "<i>Analysis on Secure Triplet Loss.</i>" (<a href="https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9965373">DOI</a>)</li>
           </ul>
@@ -711,7 +711,7 @@ header:
           <time class="cna-card-meta">Sep 27, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper won the grand prize at "<b style="color:var(--cna-forest)">National Cryptographic Technology Contest, 2022</b>". Congrats <b>Hyeonbum Lee</b>, who was the lead author of this submission.
+          The following paper won the grand prize at "<b>National Cryptographic Technology Contest, 2022</b>". Congrats <b>Hyeonbum Lee</b>, who was the lead author of this submission.
           <ul>
             <li><b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b>, "<i>Non-Pairing Sublinear Verifiable Zero-Knowledge Arguments in Discrete Logarithm Setting</i>"</li>
           </ul>
@@ -724,7 +724,7 @@ header:
           <time class="cna-card-meta">Sep 27, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper won the special prize at "<b style="color:var(--cna-forest)">National Cryptographic Technology Contest, 2022</b>". Congrats <b>Sunpill Kim</b>, who was the lead author of this submission.
+          The following paper won the special prize at "<b>National Cryptographic Technology Contest, 2022</b>". Congrats <b>Sunpill Kim</b>, who was the lead author of this submission.
           <ul>
             <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b> "<i>Deep Face Template Protection in the Wild</i>"</li>
           </ul>
@@ -737,7 +737,7 @@ header:
           <time class="cna-card-meta">Sep 20, 2022</time>
         </header>
         <div class="cna-card-body">
-          HUCC, Crypto Club of Hanyang University, won an award for excellence (우수상) in "<b style="color:var(--cna-forest)">Crypto Analysis Contest, 2022</b>", hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
+          HUCC, Crypto Club of Hanyang University, won an award for excellence (우수상) in "<b>Crypto Analysis Contest, 2022</b>", hosted by Military Crypto Research Center. Congrats two of C&amp;A members, <b>Seunghun Paik</b> and <b>Minsu Kim</b>, who are a leader and a member of HUCC.
         </div>
       </article>
 
@@ -777,7 +777,7 @@ header:
           <time class="cna-card-meta">Aug 25, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted for presentation at the <b style="color:var(--cna-indigo)">ASIACRYPT</b> 2022.
+          The following paper has been accepted for presentation at the <b>ASIACRYPT</b> 2022.
           <ul>
             <li>Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b>, "<i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i>"</li>
           </ul>
@@ -810,7 +810,7 @@ header:
           <time class="cna-card-meta">Jun 10, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted in <b style="color:var(--cna-indigo)">IEEE Blockchain</b>.
+          The following paper has been accepted in <b>IEEE Blockchain</b>.
           <ul>
             <li><b>Chanyang Ju</b>, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung "<i>Monitoring Provenance of Delegated Personal Data With Blockchain</i>"</li>
           </ul>
@@ -843,7 +843,7 @@ header:
           <time class="cna-card-meta">Apr 18, 2022</time>
         </header>
         <div class="cna-card-body">
-          The following paper has been accepted at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          The following paper has been accepted at <b>IEEE Access</b>.
           <ul>
             <li><b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b> "<i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger</i>" (<a href="https://ieeexplore.ieee.org/document/9758733">DOI</a>)</li>
           </ul>
@@ -899,7 +899,7 @@ header:
           <time class="cna-card-meta">Dec 8, 2021</time>
         </header>
         <div class="cna-card-body">
-          Our paper (<a href="https://ieeexplore.ieee.org/document/9638642">Efficient Sum-Check Protocol for Convolution</a>) is accepted at <b style="color:var(--cna-crimson)">IEEE Access</b>.
+          Our paper (<a href="https://ieeexplore.ieee.org/document/9638642">Efficient Sum-Check Protocol for Convolution</a>) is accepted at <b>IEEE Access</b>.
         </div>
       </article>
 
@@ -1038,7 +1038,7 @@ header:
           <time class="cna-card-meta">2020</time>
         </header>
         <div class="cna-card-body">
-          Our paper (<a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask: Modular Architecture for Protecting Deep Face Template</a>) is accepted at <a href="http://cvpr2021.thecvf.com/"><b style="color:var(--cna-indigo)">CVPR</b> 2021</a>.
+          Our paper (<a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">IronMask: Modular Architecture for Protecting Deep Face Template</a>) is accepted at <a href="http://cvpr2021.thecvf.com/"><b>CVPR</b> 2021</a>.
         </div>
       </article>
 
@@ -1048,7 +1048,7 @@ header:
           <time class="cna-card-meta">2020</time>
         </header>
         <div class="cna-card-body">
-          [<a href="https://eprint.iacr.org/2020/735">Bulletproofs+</a>] Participant Prizes (2020) in the <b style="color:var(--cna-forest)">National Cryptographic Technology Contest</b>, National Intelligence Service, Korea.
+          [<a href="https://eprint.iacr.org/2020/735">Bulletproofs+</a>] Participant Prizes (2020) in the <b>National Cryptographic Technology Contest</b>, National Intelligence Service, Korea.
         </div>
       </article>
 

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -9,7 +9,7 @@ permalink: /News/previous_event/
 excerpt: 'previous events..'
 header:
   overlay_image: /assets/images/korea.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 # Previous Events
 

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -88,9 +88,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">Oct 15, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -227,9 +227,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">Jun 5, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -247,9 +247,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">Apr 8, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -402,9 +402,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">Jun 5, 2024</time>
         </header>
         <div class="cna-card-body">
@@ -580,9 +580,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">Jul 13, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -971,9 +971,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Seminar</span>
+          <span class="cna-chip cna-chip-seminar">Seminar</span>
           <time class="cna-card-meta">2021</time>
         </header>
         <div class="cna-card-body">
@@ -1070,9 +1070,9 @@ header:
       <summary><b>IVC</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">6/27 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">6/27 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1081,9 +1081,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/6 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">7/6 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1092,9 +1092,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/11 · 19:00</span>
+            <span class="cna-chip cna-chip-seminar">7/11 · 19:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1103,9 +1103,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/18 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">7/18 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1114,9 +1114,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/25 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">7/25 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1125,9 +1125,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/1 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">8/1 · 13:00</span>
             <span class="cna-card-meta">751</span>
           </header>
           <div class="cna-card-body">
@@ -1136,9 +1136,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/8 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">8/8 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1147,9 +1147,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/14 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">8/14 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1158,9 +1158,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-chip cna-chip-seminar">TBD</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1176,9 +1176,9 @@ header:
       <summary><b>Deep Learning</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/12 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1187,9 +1187,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/12 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1198,9 +1198,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/19 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/19 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1209,9 +1209,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/19 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/19 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1220,9 +1220,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/26 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/26 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1231,9 +1231,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/2 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/2 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1242,9 +1242,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/2 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/2 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1253,9 +1253,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/9 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/9 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1264,9 +1264,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/16 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/16 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1275,9 +1275,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/30 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/30 · 10:00</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1286,9 +1286,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">9/1 · 15:00</span>
+            <span class="cna-chip cna-chip-seminar">9/1 · 15:00</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1304,9 +1304,9 @@ header:
       <summary><b>ZKP Basic</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/07 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">7/07 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1315,9 +1315,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/14 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/14 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1326,9 +1326,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/21 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">7/21 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1337,9 +1337,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/28 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">7/28 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1348,9 +1348,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/04 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">8/04 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1359,9 +1359,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/10 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">8/10 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1392,9 +1392,9 @@ header:
       <summary><b>Deep Learning</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/2 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/2 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1403,9 +1403,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/2 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/2 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1414,9 +1414,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/16 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/16 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1425,9 +1425,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/16 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/16 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1436,9 +1436,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/26 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/26 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1447,9 +1447,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/30 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/30 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1458,9 +1458,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/30 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/30 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1469,9 +1469,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/13 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/13 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1480,9 +1480,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/13 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/13 · 13:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1491,9 +1491,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/20 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/20 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1502,9 +1502,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/20 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/20 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1513,9 +1513,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-chip cna-chip-seminar">TBD</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1524,9 +1524,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-chip cna-chip-seminar">TBD</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1545,9 +1545,9 @@ header:
           Textbook: <b>A Computational Introduction to Number Theory and Algebra</b>, Second Edition.
         </p>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/5 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/5 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1555,9 +1555,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/12 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/12 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1565,9 +1565,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/19 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/19 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1575,9 +1575,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/26 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">1/26 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1585,9 +1585,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/2 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/2 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1595,9 +1595,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/9 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/9 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1605,9 +1605,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/16 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/16 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1615,9 +1615,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/23 · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">2/23 · 13:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1632,9 +1632,9 @@ header:
       <summary><b>Algorithm</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">Every Wed · 13:00</span>
+            <span class="cna-chip cna-chip-seminar">Every Wed · 13:00</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1649,9 +1649,9 @@ header:
       <summary><b>Zero Knowledge Proof</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">TBD</span>
+            <span class="cna-chip cna-chip-seminar">TBD</span>
             <span class="cna-card-meta">TBA</span>
           </header>
           <div class="cna-card-body">
@@ -1677,9 +1677,9 @@ header:
       <summary><b>Deep Learning</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/7 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1688,9 +1688,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/7 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1699,9 +1699,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/7 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1710,9 +1710,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/13 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1721,9 +1721,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/13 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1732,9 +1732,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/13 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/13 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1743,9 +1743,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/20 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/20 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1754,9 +1754,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">1/27 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">1/27 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1765,9 +1765,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/3 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">2/3 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1776,9 +1776,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">2/10 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">2/10 · 10:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1787,9 +1787,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/6 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/6 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1798,9 +1798,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/13 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/13 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1809,9 +1809,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/20 · 11:00</span>
+            <span class="cna-chip cna-chip-seminar">7/20 · 11:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1820,9 +1820,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/27 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">7/27 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1831,9 +1831,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/3 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/3 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1842,9 +1842,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/17 · 10:00</span>
+            <span class="cna-chip cna-chip-seminar">8/17 · 10:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1853,9 +1853,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">9/16 · 11:00</span>
+            <span class="cna-chip cna-chip-seminar">9/16 · 11:00</span>
             <span class="cna-card-meta">751</span>
           </header>
           <div class="cna-card-body">
@@ -1871,9 +1871,9 @@ header:
       <summary><b>Modern Cryptography</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">9/20 · 17:30</span>
+            <span class="cna-chip cna-chip-seminar">9/20 · 17:30</span>
             <span class="cna-card-meta">740</span>
           </header>
           <div class="cna-card-body">
@@ -1882,9 +1882,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">9/27 · 17:30</span>
+            <span class="cna-chip cna-chip-seminar">9/27 · 17:30</span>
             <span class="cna-card-meta">740</span>
           </header>
           <div class="cna-card-body">
@@ -1900,9 +1900,9 @@ header:
       <summary><b>Proof-Carrying Data</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">6/30 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">6/30 · 16:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1911,9 +1911,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/14 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">7/14 · 16:00</span>
             <span class="cna-card-meta">701</span>
           </header>
           <div class="cna-card-body">
@@ -1922,9 +1922,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/21 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">7/21 · 16:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1933,9 +1933,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">8/8 · 14:00</span>
+            <span class="cna-chip cna-chip-seminar">8/8 · 14:00</span>
             <span class="cna-card-meta">702</span>
           </header>
           <div class="cna-card-body">
@@ -1951,9 +1951,9 @@ header:
       <summary><b>Zero Knowledge Proof</b></summary>
       <div class="cna-card-grid" style="margin-top:var(--cna-s-3);">
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/5 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">7/5 · 16:00</span>
             <span class="cna-card-meta">740</span>
           </header>
           <div class="cna-card-body">
@@ -1962,9 +1962,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/12 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">7/12 · 16:00</span>
             <span class="cna-card-meta">740</span>
           </header>
           <div class="cna-card-body">
@@ -1973,9 +1973,9 @@ header:
           </div>
         </article>
 
-        <article class="cna-card cna-cat-talk">
+        <article class="cna-card cna-cat-seminar">
           <header class="cna-card-head">
-            <span class="cna-chip cna-chip-talk">7/19 · 16:00</span>
+            <span class="cna-chip cna-chip-seminar">7/19 · 16:00</span>
             <span class="cna-card-meta">740</span>
           </header>
           <div class="cna-card-body">
@@ -1999,9 +1999,9 @@ header:
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">1/7 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">1/7 · 10:00</span>
           <a class="cna-card-meta" href="https://zoom.us/j/91625915128#success">Zoom ↗</a>
         </header>
         <div class="cna-card-body">
@@ -2010,9 +2010,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">1/21 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">1/21 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2021,9 +2021,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">1/28 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">1/28 · 10:00</span>
           <a class="cna-card-meta" href="https://us02web.zoom.us/j/86870082959">Zoom ↗</a>
         </header>
         <div class="cna-card-body">
@@ -2032,9 +2032,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">2/4 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">2/4 · 10:00</span>
           <a class="cna-card-meta" href="https://us02web.zoom.us/j/6830970476">Zoom ↗</a>
         </header>
         <div class="cna-card-body">
@@ -2043,9 +2043,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/2 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/2 · 10:00</span>
           <span class="cna-card-meta">자연과학관 707호</span>
         </header>
         <div class="cna-card-body">
@@ -2054,9 +2054,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/12 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/12 · 10:00</span>
           <a class="cna-card-meta" href="https://us02web.zoom.us/j/87310910372">Zoom ↗</a>
         </header>
         <div class="cna-card-body">
@@ -2065,9 +2065,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/16 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/16 · 10:00</span>
           <a class="cna-card-meta" href="https://us02web.zoom.us/j/87310910372">Zoom ↗</a>
         </header>
         <div class="cna-card-body">
@@ -2089,9 +2089,9 @@ header:
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">6/25/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">6/25/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2100,9 +2100,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/9/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/9/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2111,9 +2111,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/9/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">7/9/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2122,9 +2122,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/16/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/16/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2133,9 +2133,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/16/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">7/16/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2144,9 +2144,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/23/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/23/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2155,9 +2155,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/23/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">7/23/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2166,9 +2166,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">7/30/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">7/30/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2177,9 +2177,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">8/6/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">8/6/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2188,9 +2188,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">8/6/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">8/6/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2199,9 +2199,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">8/13/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">8/13/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2210,9 +2210,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">8/13/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">8/13/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 702호</span>
         </header>
         <div class="cna-card-body">
@@ -2221,9 +2221,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">10/19/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">10/19/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2232,9 +2232,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">10/26/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">10/26/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2243,9 +2243,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">10/26/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">10/26/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2254,9 +2254,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/5/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">11/5/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 746호</span>
         </header>
         <div class="cna-card-body">
@@ -2265,9 +2265,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/9/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">11/9/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2276,9 +2276,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/9/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">11/9/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2287,9 +2287,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/16/2020 · 10:00</span>
+          <span class="cna-chip cna-chip-seminar">11/16/2020 · 10:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2298,9 +2298,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/16/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">11/16/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2309,9 +2309,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">11/19/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">11/19/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2320,9 +2320,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">12/10/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">12/10/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">
@@ -2331,9 +2331,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">12/24/2020 · 14:00</span>
+          <span class="cna-chip cna-chip-seminar">12/24/2020 · 14:00</span>
           <span class="cna-card-meta">자연과학관 751호</span>
         </header>
         <div class="cna-card-body">

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -25,7 +25,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Dec 22, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -38,7 +38,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Dec 03, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -49,9 +49,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Nov 20, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -64,7 +64,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Nov 15, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -75,9 +75,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Oct 23, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -126,9 +126,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Sep 19, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -139,9 +139,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Sep 07, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -201,9 +201,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Jun 26, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -214,9 +214,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Jun 22, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -286,7 +286,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Jan 1, 2025</time>
         </header>
         <div class="cna-card-body">
@@ -362,9 +362,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Jul 1, 2024</time>
         </header>
         <div class="cna-card-body">
@@ -455,9 +455,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Mar 1, 2024</time>
         </header>
         <div class="cna-card-body">
@@ -480,7 +480,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Feb 5, 2024</time>
         </header>
         <div class="cna-card-body">
@@ -504,9 +504,9 @@ header:
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Oct 29, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -554,9 +554,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Aug 22, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -569,7 +569,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Jul 25, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -600,9 +600,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">May 31, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -625,7 +625,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Apr 20, 2023</time>
         </header>
         <div class="cna-card-body">
@@ -684,7 +684,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Dec 10, 2022</time>
         </header>
         <div class="cna-card-body">
@@ -771,9 +771,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Aug 25, 2022</time>
         </header>
         <div class="cna-card-body">
@@ -804,9 +804,9 @@ header:
         </div>
       </article>
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">Jun 10, 2022</time>
         </header>
         <div class="cna-card-body">
@@ -839,7 +839,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Apr 18, 2022</time>
         </header>
         <div class="cna-card-body">
@@ -895,7 +895,7 @@ header:
 
       <article class="cna-card cna-cat-paper">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-paper">Journal</span>
           <time class="cna-card-meta">Dec 8, 2021</time>
         </header>
         <div class="cna-card-body">
@@ -1032,9 +1032,9 @@ header:
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-paper">
+      <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-paper">Paper</span>
+          <span class="cna-chip cna-chip-talk">Conference</span>
           <time class="cna-card-meta">2020</time>
         </header>
         <div class="cna-card-body">

--- a/_pages/Previous events.md
+++ b/_pages/Previous events.md
@@ -11,7 +11,6 @@ header:
   overlay_image: /assets/images/korea.jpg
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
-# Previous Events
 
 ## Previous News
 

--- a/_pages/Projects.md
+++ b/_pages/Projects.md
@@ -142,7 +142,7 @@ header:
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip">CRYPTOLAB</span>
-      <span class="cna-row-aside-detail">Industry</span>
+      <span class="cna-row-aside-detail">(주)크립토랩</span>
     </div>
   </article>
 

--- a/_pages/Projects.md
+++ b/_pages/Projects.md
@@ -12,52 +12,52 @@ header:
 
 ## Ongoing
 
-<div class="cna-card-grid" markdown="0">
+<div class="cna-projects" markdown="0">
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2025<br>– Aug 2026</span>
+    <span class="cna-row-meta">Sep 2025 – Aug 2026</span>
     <div class="cna-row-main">
       <div class="cna-row-title">신원 보존 역모델 설계: 화자 인식 시스템의 취약성 탐구</div>
       <div class="cna-row-sub"><i>Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2025<br>– Aug 2026</span>
+    <span class="cna-row-meta">Sep 2025 – Aug 2026</span>
     <div class="cna-row-main">
       <div class="cna-row-title">안전한 퍼지 교집합 연산 프로토콜 설계 기법 연구</div>
       <div class="cna-row-sub"><i>A Study of Fuzzy Private Set Intersection</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2024<br>– Dec 2027</span>
+    <span class="cna-row-meta">Apr 2024 – Dec 2027</span>
     <div class="cna-row-main">
       <div class="cna-row-title">차세대 저작권 침해 방지 기술 및 안전한 콘텐츠 유통 기술 개발을 위한 국제 공동 연구</div>
       <div class="cna-row-sub"><i>International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">KOCCA</span>
+      <span class="cna-chip">KOCCA</span>
       <span class="cna-row-aside-detail">한국콘텐츠진흥원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2021<br>– Dec 2026</span>
+    <span class="cna-row-meta">Apr 2021 – Dec 2026</span>
     <div class="cna-row-main">
       <div class="cna-row-title">간결한 비대화형 연산 증명 시스템(SNARK)를 위한 암호 원천 기술 개발</div>
       <div class="cna-row-sub"><i>A Study on Cryptographic Primitives for SNARK</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-chip">IITP</span>
       <span class="cna-row-aside-detail">정보통신기획평가원</span>
     </div>
   </article>
@@ -72,112 +72,112 @@ header:
     <span class="cna-year-count">9 projects</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
-  <div class="cna-year-body">
+  <div class="cna-year-body cna-projects">
 
   <article class="cna-row">
-    <span class="cna-row-meta">Feb 2025<br>– Dec 2025</span>
+    <span class="cna-row-meta">Feb 2025 – Dec 2025</span>
     <div class="cna-row-main">
       <div class="cna-row-title">상용 얼굴인식 API의 적대적 공격 및 안전성 분석</div>
       <div class="cna-row-sub"><i>Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">KIISC</span>
+      <span class="cna-chip">KIISC</span>
       <span class="cna-row-aside-detail">한국정보보호학회 암호연구회</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2024<br>– Aug 2025</span>
+    <span class="cna-row-meta">Sep 2024 – Aug 2025</span>
     <div class="cna-row-main">
       <div class="cna-row-title">영지식 증명을 통한 점진적으로 검증 가능한 연산에 관한 연구</div>
       <div class="cna-row-sub"><i>A Study on Incrementally Verifiable Computation through Zero-Knowledge Proof</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2024<br>– Aug 2025</span>
+    <span class="cna-row-meta">Sep 2024 – Aug 2025</span>
     <div class="cna-row-main">
       <div class="cna-row-title">딥러닝 기반 생체인식 시스템을 이용한 안전한 인증 시스템</div>
       <div class="cna-row-sub"><i>Secure Authentication System using Deep Learning-based Biometric Recognition System</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Mar 2020<br>– Feb 2025</span>
+    <span class="cna-row-meta">Mar 2020 – Feb 2025</span>
     <div class="cna-row-main">
       <div class="cna-row-title">양자내성을 가지는 효율적 단방향 영지식 증명 방법에 관한 연구</div>
       <div class="cna-row-sub"><i>Research on Post-Quantum Non-Interactive Zero-Knowledge Proofs</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2021<br>– Aug 2024</span>
+    <span class="cna-row-meta">Sep 2021 – Aug 2024</span>
     <div class="cna-row-main">
       <div class="cna-row-title">다자간 근사계산 암호 원천기술 개발</div>
       <div class="cna-row-sub"><i>Secure Multi-party Approximate Computation</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">Samsung SSTF</span>
+      <span class="cna-chip">Samsung SSTF</span>
       <span class="cna-row-aside-detail">삼성미래기술육성재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Jul 2022<br>– Jun 2023</span>
+    <span class="cna-row-meta">Jul 2022 – Jun 2023</span>
     <div class="cna-row-main">
       <div class="cna-row-title">암호화 얼굴 템플릿 DB 검색 기술 개발</div>
       <div class="cna-row-sub"><i>Development of Encrypted Face Template DB Search Technology</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">CRYPTOLAB</span>
+      <span class="cna-chip">CRYPTOLAB</span>
       <span class="cna-row-aside-detail">Industry</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">May 2022<br>– Apr 2023</span>
+    <span class="cna-row-meta">May 2022 – Apr 2023</span>
     <div class="cna-row-main">
       <div class="cna-row-title">다중 계층 블록체인 기반의 로그 저장 및 영지식 증명 방법</div>
       <div class="cna-row-sub"><i>Logging and Zero-knowledge Proof based on Hierarchical Blockchain</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-chip">IITP</span>
       <span class="cna-row-aside-detail">정보통신기획평가원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Feb 2022<br>– Nov 2022</span>
+    <span class="cna-row-meta">Feb 2022 – Nov 2022</span>
     <div class="cna-row-main">
       <div class="cna-row-title">딥러닝 기반 얼굴인식 기술에서의 생체정보 추출 위협 및 대응방안 연구</div>
       <div class="cna-row-sub"><i>A study on biometric information extraction threats and countermeasures in deep learning-based face recognition system</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">KIISC</span>
+      <span class="cna-chip">KIISC</span>
       <span class="cna-row-aside-detail">한국정보보호학회 암호연구회</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2022<br>– Oct 2022</span>
+    <span class="cna-row-meta">Apr 2022 – Oct 2022</span>
     <div class="cna-row-main">
       <div class="cna-row-title">Proof-Carrying-Data에 적합한 암호학적 증명시스템 설계 기술 연구</div>
       <div class="cna-row-sub"><i>Research on the design technology of a cryptographic proof system suitable for Proof-Carrying Data</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-chip">NSR</span>
       <span class="cna-row-aside-detail">국가보안기술연구소</span>
     </div>
   </article>
@@ -191,73 +191,73 @@ header:
     <span class="cna-year-count">6 projects</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
-  <div class="cna-year-body">
+  <div class="cna-year-body cna-projects">
 
   <article class="cna-row">
-    <span class="cna-row-meta">May 2021<br>– Apr 2022</span>
+    <span class="cna-row-meta">May 2021 – Apr 2022</span>
     <div class="cna-row-main">
       <div class="cna-row-title">검색 가능한 블록체인기반 프로비넌스 로그의 프라이버시 보호를 위한 영지식 증명 기법 연구</div>
       <div class="cna-row-sub"><i>Blockchain and Zero Knowledge Proof for Searchable and Privacy-preserving Provenance Logging</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-chip">IITP</span>
       <span class="cna-row-aside-detail">정보통신기획평가원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2021<br>– Oct 2021</span>
+    <span class="cna-row-meta">Apr 2021 – Oct 2021</span>
     <div class="cna-row-main">
       <div class="cna-row-title">점진적 검증가능연산 설계기법 및 적용방안 연구</div>
       <div class="cna-row-sub"><i>Research on Incrementally Verifiable Computation Design Technique and Application Method</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-chip">NSR</span>
       <span class="cna-row-aside-detail">국가보안기술연구소</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Nov 2016<br>– Jul 2021</span>
+    <span class="cna-row-meta">Nov 2016 – Jul 2021</span>
     <div class="cna-row-main">
       <div class="cna-row-title">함수암호 기법 설계·분석 및 구현기술 연구</div>
       <div class="cna-row-sub"><i>Research on Functional Encryption Technique Design, Analysis and Implementation Technology</i></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-chip">IITP</span>
       <span class="cna-row-aside-detail">정보통신기획평가원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2020<br>– Oct 2020</span>
+    <span class="cna-row-meta">Apr 2020 – Oct 2020</span>
     <div class="cna-row-main">
       <div class="cna-row-title">양자내성 영지식 증명 설계기법 및 적용방안 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-chip">NSR</span>
       <span class="cna-row-aside-detail">국가보안기술연구소</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">May 2019<br>– Oct 2020</span>
+    <span class="cna-row-meta">May 2019 – Oct 2020</span>
     <div class="cna-row-main">
       <div class="cna-row-title">격자 기반 영지식 증명 설계 기법 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-chip">NSR</span>
       <span class="cna-row-aside-detail">국가보안기술연구소</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Dec 2018<br>– Dec 2019</span>
+    <span class="cna-row-meta">Dec 2018 – Dec 2019</span>
     <div class="cna-row-main">
       <div class="cna-row-title">실수 기반 Fuzzy Extractor 기술 개발</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-chip">Samsung</span>
       <span class="cna-row-aside-detail">삼성전자</span>
     </div>
   </article>
@@ -271,81 +271,81 @@ header:
     <span class="cna-year-count">7 projects</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
-  <div class="cna-year-body">
+  <div class="cna-year-body cna-projects">
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2018<br>– Nov 2018</span>
+    <span class="cna-row-meta">Apr 2018 – Nov 2018</span>
     <div class="cna-row-main">
       <div class="cna-row-title">생체 정보 기반 암호화 기술 개발</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-chip">Samsung</span>
       <span class="cna-row-aside-detail">삼성전자</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Mar 2017<br>– Feb 2020</span>
+    <span class="cna-row-meta">Mar 2017 – Feb 2020</span>
     <div class="cna-row-main">
       <div class="cna-row-title">격자 구조가 가지는 암호학적 성질에 관한 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-chip">NRF</span>
       <span class="cna-row-aside-detail">과학기술정보통신부 / 한국연구재단</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Jun 2016<br>– Nov 2016</span>
+    <span class="cna-row-meta">Jun 2016 – Nov 2016</span>
     <div class="cna-row-main">
       <div class="cna-row-title">암호화 데이터의 효과적인 구간 검색 기술 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">ETRI</span>
+      <span class="cna-chip">ETRI</span>
       <span class="cna-row-aside-detail">한국전자통신연구원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">May 2016<br>– Dec 2016</span>
+    <span class="cna-row-meta">May 2016 – Dec 2016</span>
     <div class="cna-row-main">
       <div class="cna-row-title">안전한 Support Vector Machine (SVM) 모델 설계를 위한 암호학적 알고리즘 분석 및 개발 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-chip">Samsung</span>
       <span class="cna-row-aside-detail">삼성전자</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">May 2015<br>– Nov 2015</span>
+    <span class="cna-row-meta">May 2015 – Nov 2015</span>
     <div class="cna-row-main">
       <div class="cna-row-title">공개키 기반 암호데이터 검색기술 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">ETRI</span>
+      <span class="cna-chip">ETRI</span>
       <span class="cna-row-aside-detail">한국전자통신연구원</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Apr 2015<br>– Dec 2015</span>
+    <span class="cna-row-meta">Apr 2015 – Dec 2015</span>
     <div class="cna-row-main">
       <div class="cna-row-title">암호학적 Multi-linear map 알고리즘 분석 및 개발 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-chip">Samsung</span>
       <span class="cna-row-aside-detail">삼성전자</span>
     </div>
   </article>
 
   <article class="cna-row">
-    <span class="cna-row-meta">Sep 2014<br>– Aug 2015</span>
+    <span class="cna-row-meta">Sep 2014 – Aug 2015</span>
     <div class="cna-row-main">
       <div class="cna-row-title">1kB 이하 암호문간의 연산을 지원하는 동형암호 원천 기술 개발 및 응용기술 연구</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Other</span>
+      <span class="cna-chip">Other</span>
       <span class="cna-row-aside-detail">미래부 / 정보통신기술진흥센터</span>
     </div>
   </article>

--- a/_pages/Projects.md
+++ b/_pages/Projects.md
@@ -7,7 +7,7 @@ permalink: /Projects/
 excerpt: 'If you have any questions, please feel free to email us.'
 header:
   overlay_image: /assets/images/Hanyang1.jfif
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 <div class="cna-tally" markdown="0">

--- a/_pages/Projects.md
+++ b/_pages/Projects.md
@@ -10,18 +10,6 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-<div class="cna-tally" markdown="0">
-  <span class="cna-tally-label">By funder</span>
-  <span class="cna-tally-pill cna-tally-paper">NRF × 6</span>
-  <span class="cna-tally-pill cna-tally-talk">IITP × 4</span>
-  <span class="cna-tally-pill cna-tally-event">Industry × 6</span>
-  <span class="cna-tally-pill cna-tally-award">NSR × 4</span>
-  <span class="cna-tally-pill cna-tally-award">KIISC × 2</span>
-  <span class="cna-tally-pill cna-tally-award">ETRI × 2</span>
-  <span class="cna-tally-pill cna-tally-award">KOCCA × 1</span>
-  <span class="cna-tally-pill cna-tally-award">Other × 1</span>
-</div>
-
 ## Ongoing
 
 <div class="cna-card-grid" markdown="0">

--- a/_pages/Projects.md
+++ b/_pages/Projects.md
@@ -10,122 +10,357 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
+<div class="cna-tally" markdown="0">
+  <span class="cna-tally-label">By funder</span>
+  <span class="cna-tally-pill cna-tally-paper">NRF × 6</span>
+  <span class="cna-tally-pill cna-tally-talk">IITP × 4</span>
+  <span class="cna-tally-pill cna-tally-event">Industry × 6</span>
+  <span class="cna-tally-pill cna-tally-award">NSR × 4</span>
+  <span class="cna-tally-pill cna-tally-award">KIISC × 2</span>
+  <span class="cna-tally-pill cna-tally-award">ETRI × 2</span>
+  <span class="cna-tally-pill cna-tally-award">KOCCA × 1</span>
+  <span class="cna-tally-pill cna-tally-award">Other × 1</span>
+</div>
+
 ## Ongoing
 
-<ul type="square">
-    <li>
-        Sep 2025 - Aug 2026, 신원 보존 역모델 설계: 화자 인식 시스템의 취약성 탐구, 한국연구재단
-        <br>
-        Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems, National Research Foundation of Korea (NRF)
-    </li> 
-    <li>
-        Sep 2025 - Aug 2026, 안전한 퍼지 교집합 연산 프로토콜 설계 기법 연구, 한국연구재단
-        <br>
-        A Study of Fuzzy Private Set Intersection, National Research Foundation of Korea (NRF)
-    </li> 
-    <li>
-        Apr 2024 - Dec 2027, 차세대 저작권 침해 방지 기술 및 안전한 콘텐츠 유통 기술 개발을 위한 국제 공동 연구, 한국콘텐츠진흥원
-        <br>
-        International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology, Korea Creative Content Agency (KOCCA)
-    </li>   
-    <li>
-        Apr 2021 - Dec 2026, 간결한 비대화형 연산 증명 시스템(SNARK)를 위한 암호 원천 기술 개발, 정보통신기획평가원
-        <br>
-        A Study on Cryptographic Primitives for SNARK, Institute for Information and Communications Technology Promotion (IITP)
-    </li>
-</ul>    
-        
+<div class="cna-card-grid" markdown="0">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2025<br>– Aug 2026</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">신원 보존 역모델 설계: 화자 인식 시스템의 취약성 탐구</div>
+      <div class="cna-row-sub"><i>Design Identity-Preserving Inverse Models: Exploring Vulnerabilities in Speaker Recognition Systems</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2025<br>– Aug 2026</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">안전한 퍼지 교집합 연산 프로토콜 설계 기법 연구</div>
+      <div class="cna-row-sub"><i>A Study of Fuzzy Private Set Intersection</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2024<br>– Dec 2027</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">차세대 저작권 침해 방지 기술 및 안전한 콘텐츠 유통 기술 개발을 위한 국제 공동 연구</div>
+      <div class="cna-row-sub"><i>International Joint Research to Develop Next-generation Copyright Infringement Prevention Technology and Safe Content Distribution Technology</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">KOCCA</span>
+      <span class="cna-row-aside-detail">한국콘텐츠진흥원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2021<br>– Dec 2026</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">간결한 비대화형 연산 증명 시스템(SNARK)를 위한 암호 원천 기술 개발</div>
+      <div class="cna-row-sub"><i>A Study on Cryptographic Primitives for SNARK</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-row-aside-detail">정보통신기획평가원</span>
+    </div>
+  </article>
+
+</div>
 
 ## Finished
-<ul type="square">
-    <li>
-        Feb 2025 - Dec 2025, 상용 얼굴인식 API의 적대적 공격 및 안전성 분석, 한국정보보호학회 암호연구회
-        <br>
-        Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs, Korea Institute of Information Security & Cryptology (KIISC)
-    </li>
-    <li>
-        Sep 2024 - Aug 2025, 영지식 증명을 통한 점진적으로 검증 가능한 연산에 관한 연구, 한국연구재단
-        <br>
-        A Study on Incremetally Verifiable Computation through Zero-Knowledge Proof, National Research Foundation of Korea (NRF)
-    </li> 
-    <li>
-        Sep 2024 - Aug 2025, 딥러닝 기반 생체인식 시스템을 이용한 안전한 인증 시스템, 한국연구재단
-        <br>
-        Secure Authentication System using Deep Learning-based Biometric Recognition System, National Research Foundation of Korea (NRF)
-    </li> 
-    <li>
-        Mar 2020 - Feb 2025, 양자내성을 가지는 효율적 단방향 영지식 증명 방법에 관한 연구, 한국연구재단
-        <br>
-        Research on Post-Quantum Non-Interactive Zero-Knowledge Proofs, National Research Foundation of KOREA (NRF)
-    </li>
-    <li>
-        Sep 2021 - Aug 2024, 다자간 근사계산 암호 원천기술 개발, 삼성미래기술육성재단
-        <br>
-        Secure Multi-party Approximate Computation, Samsung Science & Technology Foundation (SSTF)
-    </li>  
-    <li>
-        Jul 2022 - Jun 2023, 암호화 얼굴 템플릿 DB 검색 기술 개발, CRYPTOLAB
-        <br>
-        Development of Encrypted Face Template DB Search Technology, CRYPTOLAB
-    </li> 
-    <li>
-        May 2022 - Apr 2023, 다중 계층 블록체인 기반의 로그 저장 및 영지식 증명 방법, 정보통신기획평가원 (IITP)
-        <br>
-        Logging and Zero-knowledge Proof based on Hierarchical Blockchain, Institute for Information and Communications Technology Promotion (IITP)
-    </li>  
-    <li>
-        Feb 2022 - Nov 2022, 딥러닝 기반 얼굴인식 기술에서의 생체정보 추출 위협 및 대응방안 연구, 한국정보보호학회 암호연구회 (KIISC)
-        <br>
-        A study on biometric information extraction threats and countermeasures in deep learning-based face recognition system, Korea Institute of Information Security & Crytology (KIISC)
-    </li>  
-    <li>
-        Apr 2022 - Oct 2022, Proof-Carrying-Data에 적합한 암호학적 증명시스템 설계 기술 연구, 국가보안기술연구소 (NSR)
-        <br>
-        Research on the design technology of a cryptographic proof system suitable for Proof-Carrying Data, National Security Research Institute (NSR)
-    </li>  
-    <li>
-        May 2021 - Apr 2022, 검색 가능한 블록체인기반 프로비넌스 로그의 프라이버시 보호를 위한 영지식 증명 기법연구, 정보통신기획평가원 (IITP)
-        <br>
-        Blockchain and Zero Knowledge Proof for Searchable and Privacy-preserving Provenance Logging, Institute for Information and Communications Technology Promotion (IITP)
-    </li>
-    <li>
-        Apr 2021 - Oct 2021, 점진적 검증가능연산 설계기법 및 적용방안 연구, 국가보안기술연구소
-        <br>
-        Research on Incrementally Verifiable Computation Design Technique and Application Method, National Security Research Institute (NSR)
-    </li>
-    <li>
-        Nov 2016 - Jul 2021, 함수암호 기법 설계·분석 및 구현기술 연구, 정보통신기획평가원 (IITP)
-        <br>
-        Research on Functional Encryption Technique Design, Analysis and Implementation Technology, Institute for Information and Communications Technology Promotion (IITP)
-    </li>
-    <li>
-        Apr 2020 - Oct 2020, 양자내성 영지식 증명 설계기법 및 적용방안 연구, 국가보안기술연구소
-    </li>
-    <li>
-        May 2019 - Oct 2020, 격자 기반 영지식 증명 설계 기법 연구, 국가보안기술연구소
-    </li>
-    <li>
-        Mar 2017 - Feb 2020, 격자 구조가 가지는 암호학적 성질에 관한 연구, 과학기술정보통신부/한국연구재단
-    </li>
-    <li>
-        Dec 2018 - Dec 2019, 실수 기반 Fuzzy Extractor 기술 개발, 삼성전자
-    </li>
-    <li>
-        Apr 2018 - Nov 2018, 생체 정보 기반 암호화 기술 개발, 삼성전자
-    </li>
-    <li>
-        Jun 2016 - Nov 2016, 암호화 데이터의 효과적인 구간 검색 기술 연구, ETRI
-    </li>
-    <li>
-        May 2016 - Dec 2016, 안전한 Support Vector Machine (SVM) 모델 설계를 위한 암호학적 알고리즘 분석 및 개발 연구, 삼성전자
-    </li>
-    <li>
-        May 2015 - Nov 2015, 공개키 기반 암호데이터 검색기술 연구, ETRI
-    </li>
-    <li>
-        Apr 2015 - Dec 2015, 암호학적 Multi-linear map 알고리즘 분석 및 개발 연구, 삼성전자
-    </li>
-    <li>
-        Sep 2014 - Aug 2015, 1kB 이하 암호문간의 연산을 지원하는 동형암호 원천 기술 개발 및 응용기술 연구, 미래부/정보통신기술진흥센터
-    </li>
-</ul>
+
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2022 – 2025</h3>
+    <span class="cna-year-count">9 projects</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Feb 2025<br>– Dec 2025</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">상용 얼굴인식 API의 적대적 공격 및 안전성 분석</div>
+      <div class="cna-row-sub"><i>Adversarial Attacks and Security Analysis on Commercial Face Recognition APIs</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">KIISC</span>
+      <span class="cna-row-aside-detail">한국정보보호학회 암호연구회</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2024<br>– Aug 2025</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">영지식 증명을 통한 점진적으로 검증 가능한 연산에 관한 연구</div>
+      <div class="cna-row-sub"><i>A Study on Incrementally Verifiable Computation through Zero-Knowledge Proof</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2024<br>– Aug 2025</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">딥러닝 기반 생체인식 시스템을 이용한 안전한 인증 시스템</div>
+      <div class="cna-row-sub"><i>Secure Authentication System using Deep Learning-based Biometric Recognition System</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Mar 2020<br>– Feb 2025</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">양자내성을 가지는 효율적 단방향 영지식 증명 방법에 관한 연구</div>
+      <div class="cna-row-sub"><i>Research on Post-Quantum Non-Interactive Zero-Knowledge Proofs</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2021<br>– Aug 2024</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">다자간 근사계산 암호 원천기술 개발</div>
+      <div class="cna-row-sub"><i>Secure Multi-party Approximate Computation</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">Samsung SSTF</span>
+      <span class="cna-row-aside-detail">삼성미래기술육성재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Jul 2022<br>– Jun 2023</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">암호화 얼굴 템플릿 DB 검색 기술 개발</div>
+      <div class="cna-row-sub"><i>Development of Encrypted Face Template DB Search Technology</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">CRYPTOLAB</span>
+      <span class="cna-row-aside-detail">Industry</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">May 2022<br>– Apr 2023</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">다중 계층 블록체인 기반의 로그 저장 및 영지식 증명 방법</div>
+      <div class="cna-row-sub"><i>Logging and Zero-knowledge Proof based on Hierarchical Blockchain</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-row-aside-detail">정보통신기획평가원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Feb 2022<br>– Nov 2022</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">딥러닝 기반 얼굴인식 기술에서의 생체정보 추출 위협 및 대응방안 연구</div>
+      <div class="cna-row-sub"><i>A study on biometric information extraction threats and countermeasures in deep learning-based face recognition system</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">KIISC</span>
+      <span class="cna-row-aside-detail">한국정보보호학회 암호연구회</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2022<br>– Oct 2022</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Proof-Carrying-Data에 적합한 암호학적 증명시스템 설계 기술 연구</div>
+      <div class="cna-row-sub"><i>Research on the design technology of a cryptographic proof system suitable for Proof-Carrying Data</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-row-aside-detail">국가보안기술연구소</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2019 – 2021</h3>
+    <span class="cna-year-count">6 projects</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">May 2021<br>– Apr 2022</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">검색 가능한 블록체인기반 프로비넌스 로그의 프라이버시 보호를 위한 영지식 증명 기법 연구</div>
+      <div class="cna-row-sub"><i>Blockchain and Zero Knowledge Proof for Searchable and Privacy-preserving Provenance Logging</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-row-aside-detail">정보통신기획평가원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2021<br>– Oct 2021</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">점진적 검증가능연산 설계기법 및 적용방안 연구</div>
+      <div class="cna-row-sub"><i>Research on Incrementally Verifiable Computation Design Technique and Application Method</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-row-aside-detail">국가보안기술연구소</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Nov 2016<br>– Jul 2021</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">함수암호 기법 설계·분석 및 구현기술 연구</div>
+      <div class="cna-row-sub"><i>Research on Functional Encryption Technique Design, Analysis and Implementation Technology</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IITP</span>
+      <span class="cna-row-aside-detail">정보통신기획평가원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2020<br>– Oct 2020</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">양자내성 영지식 증명 설계기법 및 적용방안 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-row-aside-detail">국가보안기술연구소</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">May 2019<br>– Oct 2020</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">격자 기반 영지식 증명 설계 기법 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">NSR</span>
+      <span class="cna-row-aside-detail">국가보안기술연구소</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Dec 2018<br>– Dec 2019</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">실수 기반 Fuzzy Extractor 기술 개발</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-row-aside-detail">삼성전자</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2014 – 2018</h3>
+    <span class="cna-year-count">7 projects</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2018<br>– Nov 2018</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">생체 정보 기반 암호화 기술 개발</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-row-aside-detail">삼성전자</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Mar 2017<br>– Feb 2020</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">격자 구조가 가지는 암호학적 성질에 관한 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">NRF</span>
+      <span class="cna-row-aside-detail">과학기술정보통신부 / 한국연구재단</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Jun 2016<br>– Nov 2016</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">암호화 데이터의 효과적인 구간 검색 기술 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">ETRI</span>
+      <span class="cna-row-aside-detail">한국전자통신연구원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">May 2016<br>– Dec 2016</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">안전한 Support Vector Machine (SVM) 모델 설계를 위한 암호학적 알고리즘 분석 및 개발 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-row-aside-detail">삼성전자</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">May 2015<br>– Nov 2015</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">공개키 기반 암호데이터 검색기술 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">ETRI</span>
+      <span class="cna-row-aside-detail">한국전자통신연구원</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Apr 2015<br>– Dec 2015</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">암호학적 Multi-linear map 알고리즘 분석 및 개발 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-event">Samsung</span>
+      <span class="cna-row-aside-detail">삼성전자</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">Sep 2014<br>– Aug 2015</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">1kB 이하 암호문간의 연산을 지원하는 동형암호 원천 기술 개발 및 응용기술 연구</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Other</span>
+      <span class="cna-row-aside-detail">미래부 / 정보통신기술진흥센터</span>
+    </div>
+  </article>
+
+  </div>
+</details>

--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -10,613 +10,545 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
-<style type="text/css">
-.cna-pubs-counter{
-  display:flex; flex-wrap:wrap; align-items:center; gap:8px;
-  margin:8px 0 24px; padding:14px 18px;
-  background:#fafaf6; border:1px solid #e6e2d8; border-radius:12px;
-  font-size:13.5px;
-}
-.cna-pubs-counter-label{ font-weight:600; color:#52575f; letter-spacing:.02em; margin-right:6px; }
-.cna-pubs-tally{
-  font-size:12px; font-weight:600; letter-spacing:.06em;
-  padding:4px 10px; border-radius:999px; white-space:nowrap;
-  background:#eaf1fa; color:#2b5285;
-}
+<div class="cna-tally" markdown="0">
+  <span class="cna-tally-label">Top conferences</span>
+  <span class="cna-tally-pill cna-tally-talk">CCS × 2</span>
+  <span class="cna-tally-pill cna-tally-talk">S&amp;P × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">NDSS × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">CVPR × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">ICCV × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">ECCV × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">NeurIPS × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">CRYPTO × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">EUROCRYPT × 1</span>
+  <span class="cna-tally-pill cna-tally-talk">ASIACRYPT × 2</span>
+</div>
 
-.cna-pubs-year{
-  border:1px solid #e6e2d8; border-radius:14px;
-  margin:0 0 12px; padding:0;
-  background:#fff;
-  box-shadow:0 1px 2px rgba(31,34,39,.04);
-}
-.cna-pubs-year > summary{
-  cursor:pointer; user-select:none; list-style:none;
-  display:flex; align-items:baseline; justify-content:space-between;
-  gap:12px; padding:14px 18px;
-  border-radius:14px;
-  transition:background .15s ease;
-}
-.cna-pubs-year > summary::-webkit-details-marker{ display:none; }
-.cna-pubs-year > summary:hover{ background:rgba(0,0,0,.025); }
-.cna-pubs-year > summary h3{
-  margin:0; padding:0; border:none;
-  font-size:1.2rem; font-weight:600; color:#1f2227;
-}
-.cna-pubs-year-count{ font-size:13px; color:#8a909a; }
-.cna-pubs-year[open] > summary{ border-bottom:1px solid #f0ecdf; border-radius:14px 14px 0 0; }
-.cna-pubs-year > .cna-pubs-list{ padding:8px 18px 14px; }
-
-.cna-pub{
-  display:grid;
-  grid-template-columns:46px 1fr 200px;
-  gap:14px; align-items:start;
-  padding:14px 0;
-  border-bottom:1px solid #f4f0e2;
-}
-.cna-pubs-list .cna-pub:last-child{ border-bottom:none; }
-
-.cna-pub-id{
-  font-size:11.5px; font-weight:700; letter-spacing:.04em;
-  color:#8a909a; padding-top:3px;
-}
-.cna-pub-main{ min-width:0; }
-.cna-pub-authors{ font-size:14.5px; color:#1f2227; line-height:1.5; }
-.cna-pub-title{ font-size:14.5px; color:#52575f; line-height:1.5; margin-top:3px; }
-.cna-pub-title i{ color:#1f2227; }
-
-.cna-pub-venue{
-  display:flex; flex-direction:column; align-items:flex-end; gap:6px;
-  font-size:12px;
-}
-.cna-venue-chip{
-  font-size:11px; font-weight:600; letter-spacing:.06em;
-  padding:4px 10px; border-radius:999px; white-space:nowrap;
-  text-align:center;
-}
-.cna-venue-chip.cna-red  { background:#fbe7eb; color:#b6102d; }
-.cna-venue-chip.cna-blue { background:#eaf1fa; color:#2b5285; }
-.cna-pub-venue-detail{ color:#8a909a; font-size:11.5px; text-align:right; }
-.cna-pub-venue-detail a{ color:#52575f; }
-
-@media (max-width:760px){
-  .cna-pub{ grid-template-columns:36px 1fr; }
-  .cna-pub-venue{ grid-column:2; align-items:flex-start; flex-direction:row; flex-wrap:wrap; gap:8px; }
-  .cna-pub-venue-detail{ text-align:left; }
-}
-</style>
-
-<div class="cna-pubs-counter" markdown="0">
-  <span class="cna-pubs-counter-label">Highlights</span>
-  <span class="cna-pubs-tally">CCS × 2</span>
-  <span class="cna-pubs-tally">S&amp;P × 1</span>
-  <span class="cna-pubs-tally">NDSS × 1</span>
-  <span class="cna-pubs-tally">CVPR × 1</span>
-  <span class="cna-pubs-tally">ICCV × 1</span>
-  <span class="cna-pubs-tally">ECCV × 1</span>
-  <span class="cna-pubs-tally">NeurIPS × 1</span>
-  <span class="cna-pubs-tally">CRYPTO × 1</span>
-  <span class="cna-pubs-tally">EUROCRYPT × 1</span>
-  <span class="cna-pubs-tally">ASIACRYPT × 2</span>
-  <span class="cna-pubs-tally">J. Cryptology × 1</span>
+<div class="cna-tally" markdown="0">
+  <span class="cna-tally-label">Top journals</span>
+  <span class="cna-tally-pill cna-tally-paper">J. Cryptology × 1</span>
+  <span class="cna-tally-pill cna-tally-paper">IEEE TIFS × 2</span>
+  <span class="cna-tally-pill cna-tally-paper">IEEE TDSC × 2</span>
+  <span class="cna-tally-pill cna-tally-paper">Pattern Recognition × 1</span>
+  <span class="cna-tally-pill cna-tally-paper">IEEE TBIOM × 1</span>
 </div>
 
 ## Journal
 
-<details class="cna-pubs-year" open markdown="0">
-  <summary><h3>2026</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" open markdown="0">
+  <summary><h3>2026</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J34</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J34</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail">TBA</span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail">TBA</span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J33</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J33</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail">TBA</span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2025</h3><span class="cna-pubs-year-count">4 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J32</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail"><a href="https://ieeexplore.ieee.org/abstract/document/11316118">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J31</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE TBIOM</span>
-      <span class="cna-pub-venue-detail"><a href="https://doi.org/10.1109/TBIOM.2025.3644396">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J30</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE TDSC</span>
-      <span class="cna-pub-venue-detail"><a href="https://ieeexplore.ieee.org/document/11269699">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J29</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Hoyong Shin and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Deep Face Template Protection in the Wild</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Pattern Recognition</span>
-      <span class="cna-pub-venue-detail">Apr 2025 · <a href="https://doi.org/10.1016/j.patcog.2024.111336">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail">TBA</span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2024</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2025</h3><span class="cna-year-count">4 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J28</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung</div>
-      <div class="cna-pub-title"><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J32</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE TDSC</span>
-      <span class="cna-pub-venue-detail">Feb 2024 · <a href="https://ieeexplore.ieee.org/document/10420492">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail"><a href="https://ieeexplore.ieee.org/abstract/document/11316118">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J31</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE TBIOM</span>
+      <span class="cna-row-aside-detail"><a href="https://doi.org/10.1109/TBIOM.2025.3644396">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J30</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE TDSC</span>
+      <span class="cna-row-aside-detail"><a href="https://ieeexplore.ieee.org/document/11269699">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J29</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Sunpill Kim</b>, Hoyong Shin and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Deep Face Template Protection in the Wild</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Pattern Recognition</span>
+      <span class="cna-row-aside-detail">Apr 2025 · <a href="https://doi.org/10.1016/j.patcog.2024.111336">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2023</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2024</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J27</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Leopard: Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J28</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung</div>
+      <div class="cna-row-sub"><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE TIFS</span>
-      <span class="cna-pub-venue-detail">Aug 2023 · <a href="https://ieeexplore.ieee.org/document/10198341">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J26</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>On the Security of Functional Encryption in the Generic Group Model.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Designs, Codes &amp; Crypto.</span>
-      <span class="cna-pub-venue-detail">May 2023 · <a href="https://doi.org/10.1007/s10623-023-01237-1">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE TDSC</span>
+      <span class="cna-row-aside-detail">Feb 2024 · <a href="https://ieeexplore.ieee.org/document/10420492">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2022</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2023</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J25</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Analysis on Secure Triplet Loss.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J27</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Leopard: Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail">Nov 2022 · <a href="https://ieeexplore.ieee.org/document/9965373">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE TIFS</span>
+      <span class="cna-row-aside-detail">Aug 2023 · <a href="https://ieeexplore.ieee.org/document/10198341">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J24</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Heewon Chung</b>, Kyoohyung Han, Chanyang Ju, Myungsun Kim, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J26</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>On the Security of Functional Encryption in the Generic Group Model.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail">Apr 2022 · <a href="https://ieeexplore.ieee.org/document/9758733">DOI</a></span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2021</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J23</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, <b>Jae Hong Seo</b>, and Sungwook Kim*</div>
-      <div class="cna-pub-title"><i>Efficient Sum-Check Protocol for Convolution.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE Access</span>
-      <span class="cna-pub-venue-detail">Dec 2021 · <a href="https://ieeexplore.ieee.org/document/9638642">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J22</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Analysis of Zero-Knowledge Protocols for Verifiable Computation and Its Applications (연산을 검증하기 위한 영지식 증명 프로토콜의 기법 및 응용 사례 분석).</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">KIISC 정보보호학회논문지</span>
-      <span class="cna-pub-venue-detail">2021 · <a href="https://www.dbpia.co.kr/pdf/pdfView.do?nodeId=NODE10596717">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J21</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Keita Emura, <b>Jae Hong Seo</b>, and Yohei Watanabe*</div>
-      <div class="cna-pub-title"><i>Efficient revocable identity-based encryption with short public parameters.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
-      <span class="cna-pub-venue-detail">Apr 2021 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397521001134">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Designs, Codes &amp; Crypto.</span>
+      <span class="cna-row-aside-detail">May 2023 · <a href="https://doi.org/10.1007/s10623-023-01237-1">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2020</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2022</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J20</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, Huaxiong Wang, and Taek-Young Youn</div>
-      <div class="cna-pub-title"><i>Public key encryption with equality test in the standard model.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J25</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Analysis on Secure Triplet Loss.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Information Sciences</span>
-      <span class="cna-pub-venue-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516322290">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail">Nov 2022 · <a href="https://ieeexplore.ieee.org/document/9965373">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J19</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>Efficient Digital Signatures from RSA without Random Oracles</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J24</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Heewon Chung</b>, Kyoohyung Han, Chanyang Ju, Myungsun Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Information Sciences</span>
-      <span class="cna-pub-venue-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025519309478?via%3Dihub">DOI</a></span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2019</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J18</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Public Key Encryption with Equality Test from Generic Assumptions in the Random Oracle Model</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Information Sciences</span>
-      <span class="cna-pub-venue-detail">2019 · <a href="https://www.sciencedirect.com/science/article/pii/S002002551930430X?via%3Dihub">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J17</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Sungwook Kim, Jinsu Kim, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>A New Approach for Practical Function-Private Inner Product Encryption.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
-      <span class="cna-pub-venue-detail">Sep 2019 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397519301690?via%3Dihub">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail">Apr 2022 · <a href="https://ieeexplore.ieee.org/document/9758733">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2018</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2021</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J16</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
-      <div class="cna-pub-title"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J23</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, <b>Jae Hong Seo</b>, and Sungwook Kim*</div>
+      <div class="cna-row-sub"><i>Efficient Sum-Check Protocol for Convolution.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Int. J. Info. Security</span>
-      <span class="cna-pub-venue-detail">2018 · <a href="https://link.springer.com/article/10.1007/s10207-017-0367-z">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J15</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Jinsu Kim, Sungwook Kim, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>A new Scale-Invariant Homomorphic Encryption Scheme.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Information Sciences</span>
-      <span class="cna-pub-venue-detail">2018 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025517309313">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE Access</span>
+      <span class="cna-row-aside-detail">Dec 2021 · <a href="https://ieeexplore.ieee.org/document/9638642">DOI</a></span>
     </div>
   </article>
 
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2017</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J14</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>Short Signatures from Diffie–Hellman: Realizing Almost Compact Public Key</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J22</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Analysis of Zero-Knowledge Protocols for Verifiable Computation and Its Applications (연산을 검증하기 위한 영지식 증명 프로토콜의 기법 및 응용 사례 분석).</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">J. Cryptology</span>
-      <span class="cna-pub-venue-detail">Jul 2017 · <a href="https://link.springer.com/article/10.1007/s00145-016-9234-8">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">KIISC 정보보호학회논문지</span>
+      <span class="cna-row-aside-detail">2021 · <a href="https://www.dbpia.co.kr/pdf/pdfView.do?nodeId=NODE10596717">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J21</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Keita Emura, <b>Jae Hong Seo</b>, and Yohei Watanabe*</div>
+      <div class="cna-row-sub"><i>Efficient revocable identity-based encryption with short public parameters.</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Theor. Computer Science</span>
+      <span class="cna-row-aside-detail">Apr 2021 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397521001134">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2016</h3><span class="cna-pubs-year-count">4 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2020</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J13</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Semi-Generic Construction of Public Key Encryption and Identity-Based Encryption with Equality Test</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J20</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, Huaxiong Wang, and Taek-Young Youn</div>
+      <div class="cna-row-sub"><i>Public key encryption with equality test in the standard model.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Information Sciences</span>
-      <span class="cna-pub-venue-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516307654">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Information Sciences</span>
+      <span class="cna-row-aside-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516322290">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J12</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b> and Huaxiong Wang</div>
-      <div class="cna-pub-title"><i>CCA2 attack and modification of Huang et al.'s public key encryption with authorized equality test</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J19</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>Efficient Digital Signatures from RSA without Random Oracles</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">The Computer Journal</span>
-      <span class="cna-pub-venue-detail">2016 · <a href="https://ieeexplore.ieee.org/document/8130169">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J11</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable hierarchical identity-based encryption via history-free approach</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
-      <span class="cna-pub-venue-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397515011354">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J10</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Keita Emura, <b>Jae Hong Seo*</b>, and Taek-Young Youn; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Semi-generic Transformation of Revocable Hierarchical Identity-Based Encryption and its DBDH Instantiation</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Jan 2016 · <a href="https://dblp.org/rec/journals/ieicet/EmuraSY16.html">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Information Sciences</span>
+      <span class="cna-row-aside-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025519309478?via%3Dihub">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2014</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2019</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J9</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable Identity-Based Encryption with Rejoin Functionality</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J18</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Public Key Encryption with Equality Test from Generic Assumptions in the Random Oracle Model</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Aug 2014 · <a href="https://search.ieice.org/bin/summary.php?id=e97-a_8_1806&category=A&year=2014&lang=E&abst=">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Information Sciences</span>
+      <span class="cna-row-aside-detail">2019 · <a href="https://www.sciencedirect.com/science/article/pii/S002002551930430X?via%3Dihub">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J8</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable Identity-Based Cryptosystem Revisited: Security Models and Constructions</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J17</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Sungwook Kim, Jinsu Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>A New Approach for Practical Function-Private Inner Product Encryption.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEEE TIFS</span>
-      <span class="cna-pub-venue-detail">2014 · <a href="https://ieeexplore.ieee.org/document/6824197?arnumber=6824197">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J7</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable Hierarchical Identity-Based Encryption</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
-      <span class="cna-pub-venue-detail">2014 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397514003363?via%3Dihub">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Theor. Computer Science</span>
+      <span class="cna-row-aside-detail">Sep 2019 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397519301690?via%3Dihub">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2013</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2018</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J6</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>A Remark on "Efficient Revocable ID-Based Encryption with a Public Channel"</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J16</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
+      <div class="cna-row-sub"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Nov 2013 · <a href="https://www.jstage.jst.go.jp/article/transfun/E96.A/11/E96.A_2282/_article">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Int. J. Info. Security</span>
+      <span class="cna-row-aside-detail">2018 · <a href="https://link.springer.com/article/10.1007/s10207-017-0367-z">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J5</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>On Discrete Logarithm based Additively Homomorphic Encryption</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J15</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Jinsu Kim, Sungwook Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>A new Scale-Invariant Homomorphic Encryption Scheme.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Nov 2013 · <a href="https://search.ieice.org/bin/summary.php?id=e96-a_11_2286&category=A&year=2013&lang=E&abst=">DOI</a></span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2012</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J4</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Jung Hee Cheon, Stanislaw Jarecki, and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Multi-Party Privacy-Preserving Set Intersection with Quasi-linear Complexity</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Aug 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_8_1366&category=A&year=2012&lang=E&abst=">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">J3</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>Short Round Sub-linear Zero-Knowledge Argument for Linear Algebraic Relations</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Apr 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_4_776&category=A&year=2012&lang=E&abst=">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Information Sciences</span>
+      <span class="cna-row-aside-detail">2018 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025517309313">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2011</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2017</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J2</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
-      <div class="cna-pub-title"><i>Anonymous Hierarchical Identity-Based Encryption with Short Ciphertexts</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J14</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>Short Signatures from Diffie–Hellman: Realizing Almost Compact Public Key</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
-      <span class="cna-pub-venue-detail">Jan 2011 · <a href="https://search.ieice.org/bin/summary.php?id=e94-a_1_45&category=A&year=2011&lang=E&abst=">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">J. Cryptology</span>
+      <span class="cna-row-aside-detail">Jul 2017 · <a href="https://link.springer.com/article/10.1007/s00145-016-9234-8">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2009</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2016</h3><span class="cna-year-count">4 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">J1</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, HyoJin Yoon, Seongan Lim, Jung Hee Cheon, and Dowon Hong</div>
-      <div class="cna-pub-title"><i>Analysis of Privacy-Preserving Element Reduction of a Multiset</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">J13</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Semi-Generic Construction of Public Key Encryption and Identity-Based Encryption with Equality Test</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-red">J. Korean Math. Soc.</span>
-      <span class="cna-pub-venue-detail">2009 · <a href="http://koreascience.or.kr/article/JAKO200907841290235.page">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Information Sciences</span>
+      <span class="cna-row-aside-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516307654">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J12</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b> and Huaxiong Wang</div>
+      <div class="cna-row-sub"><i>CCA2 attack and modification of Huang et al.'s public key encryption with authorized equality test</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">The Computer Journal</span>
+      <span class="cna-row-aside-detail">2016 · <a href="https://ieeexplore.ieee.org/document/8130169">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J11</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable hierarchical identity-based encryption via history-free approach</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Theor. Computer Science</span>
+      <span class="cna-row-aside-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397515011354">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J10</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Keita Emura, <b>Jae Hong Seo*</b>, and Taek-Young Youn; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Semi-generic Transformation of Revocable Hierarchical Identity-Based Encryption and its DBDH Instantiation</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Jan 2016 · <a href="https://dblp.org/rec/journals/ieicet/EmuraSY16.html">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2014</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J9</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable Identity-Based Encryption with Rejoin Functionality</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Aug 2014 · <a href="https://search.ieice.org/bin/summary.php?id=e97-a_8_1806&category=A&year=2014&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J8</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable Identity-Based Cryptosystem Revisited: Security Models and Constructions</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE TIFS</span>
+      <span class="cna-row-aside-detail">2014 · <a href="https://ieeexplore.ieee.org/document/6824197?arnumber=6824197">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J7</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable Hierarchical Identity-Based Encryption</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">Theor. Computer Science</span>
+      <span class="cna-row-aside-detail">2014 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397514003363?via%3Dihub">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2013</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J6</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>A Remark on "Efficient Revocable ID-Based Encryption with a Public Channel"</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Nov 2013 · <a href="https://www.jstage.jst.go.jp/article/transfun/E96.A/11/E96.A_2282/_article">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J5</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>On Discrete Logarithm based Additively Homomorphic Encryption</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Nov 2013 · <a href="https://search.ieice.org/bin/summary.php?id=e96-a_11_2286&category=A&year=2013&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2012</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J4</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Jung Hee Cheon, Stanislaw Jarecki, and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Multi-Party Privacy-Preserving Set Intersection with Quasi-linear Complexity</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Aug 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_8_1366&category=A&year=2012&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J3</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>Short Round Sub-linear Zero-Knowledge Argument for Linear Algebraic Relations</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Apr 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_4_776&category=A&year=2012&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2011</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J2</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
+      <div class="cna-row-sub"><i>Anonymous Hierarchical Identity-Based Encryption with Short Ciphertexts</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEICE Trans. Fundamentals</span>
+      <span class="cna-row-aside-detail">Jan 2011 · <a href="https://search.ieice.org/bin/summary.php?id=e94-a_1_45&category=A&year=2011&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2009</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J1</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, HyoJin Yoon, Seongan Lim, Jung Hee Cheon, and Dowon Hong</div>
+      <div class="cna-row-sub"><i>Analysis of Privacy-Preserving Element Reduction of a Multiset</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">J. Korean Math. Soc.</span>
+      <span class="cna-row-aside-detail">2009 · <a href="http://koreascience.or.kr/article/JAKO200907841290235.page">DOI</a></span>
     </div>
   </article>
 
@@ -625,463 +557,463 @@ header:
 
 ## Conference
 
-<details class="cna-pubs-year" open markdown="0">
-  <summary><h3>2026</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" open markdown="0">
+  <summary><h3>2026</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C31</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C31</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ACM CCS</span>
-      <span class="cna-pub-venue-detail">2026 · TBA</span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ACM CCS</span>
+      <span class="cna-row-aside-detail">2026 · TBA</span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C30</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo*</b>, and Taeho Jung*</div>
-      <div class="cna-pub-title"><i>Scalable Private Set Intersection over Distributed Encrypted Data</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C30</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo*</b>, and Taeho Jung*</div>
+      <div class="cna-row-sub"><i>Scalable Private Set Intersection over Distributed Encrypted Data</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ASIACCS</span>
-      <span class="cna-pub-venue-detail">2026 · TBA</span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C29</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung</div>
-      <div class="cna-pub-title"><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">NDSS</span>
-      <span class="cna-pub-venue-detail">2026 · TBA</span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ASIACCS</span>
+      <span class="cna-row-aside-detail">2026 · TBA</span>
     </div>
   </article>
 
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2025</h3><span class="cna-pubs-year-count">5 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C28</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Non-Adaptive Adversarial Face Generation</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C29</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung</div>
+      <div class="cna-row-sub"><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">NeurIPS</span>
-      <span class="cna-pub-venue-detail">2025 · TBA</span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C27</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>A Survey of Model Inversion Attacks on Image Domain</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ICTC</span>
-      <span class="cna-pub-venue-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388195">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C26</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>A Survey on Fuzzy Private Set Intersection Protocols</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ICTC</span>
-      <span class="cna-pub-venue-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388448">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C25</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Sunpill Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>IDFace: Face Template Protection for Secure and Efficient Identification</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ICCV</span>
-      <span class="cna-pub-venue-detail">2025 · <a href="https://openaccess.thecvf.com/content/ICCV2025/html/Kim_IDFace_Face_Template_Protection_for_Efficient_and_Secure_Identification_ICCV_2025_paper.html">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C24</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Jaehwan Park&dagger;, <b>Hyeonbum Lee&dagger;</b>, Junbeom Hur, <b>Jae Hong Seo*</b> and Doowon Kim*</div>
-      <div class="cna-pub-title"><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ESORICS</span>
-      <span class="cna-pub-venue-detail">2025 · <a href="https://link.springer.com/chapter/10.1007/978-3-032-07891-9_17">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">NDSS</span>
+      <span class="cna-row-aside-detail">2026 · TBA</span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2024</h3><span class="cna-pubs-year-count">4 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2025</h3><span class="cna-year-count">5 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C23</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Towards Certifiably Robust Face Recognition</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C28</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Non-Adaptive Adversarial Face Generation</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ECCV</span>
-      <span class="cna-pub-venue-detail">2024 · <a href="https://doi.org/10.1007/978-3-031-73013-9_9">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">NeurIPS</span>
+      <span class="cna-row-aside-detail">2025 · TBA</span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C22</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>On the Certifiable Robustness of Face Recognition Systems</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C27</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>A Survey of Model Inversion Attacks on Image Domain</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">CISC-S</span>
-      <span class="cna-pub-venue-detail">2024</span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C21</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung</div>
-      <div class="cna-pub-title"><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IEEE ICBC</span>
-      <span class="cna-pub-venue-detail">2024 · <a href="https://ieeexplore.ieee.org/document/10634378">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ICTC</span>
+      <span class="cna-row-aside-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388195">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C20</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C26</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>A Survey on Fuzzy Private Set Intersection Protocols</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IEEE S&amp;P</span>
-      <span class="cna-pub-venue-detail">2024 · <a href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</a></span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2023</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C19</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">BMVC (Oral)</span>
-      <span class="cna-pub-venue-detail">2023 · <a href="https://papers.bmvc2023.org/0535.pdf">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ICTC</span>
+      <span class="cna-row-aside-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388448">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C18</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>TENET : Sublogarithmic Proof and Sublinear Verifier Inner Product Argument without a Trusted Setup.</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C25</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Sunpill Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>IDFace: Face Template Protection for Secure and Efficient Identification</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IWSEC</span>
-      <span class="cna-pub-venue-detail">2023 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-41326-1_12">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ICCV</span>
+      <span class="cna-row-aside-detail">2025 · <a href="https://openaccess.thecvf.com/content/ICCV2025/html/Kim_IDFace_Face_Template_Protection_for_Efficient_and_Secure_Identification_ICCV_2025_paper.html">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C24</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Jaehwan Park&dagger;, <b>Hyeonbum Lee&dagger;</b>, Junbeom Hur, <b>Jae Hong Seo*</b> and Doowon Kim*</div>
+      <div class="cna-row-sub"><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ESORICS</span>
+      <span class="cna-row-aside-detail">2025 · <a href="https://link.springer.com/chapter/10.1007/978-3-032-07891-9_17">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2022</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2024</h3><span class="cna-year-count">4 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C17</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C23</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Towards Certifiably Robust Face Recognition</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-ASIACRYPT</span>
-      <span class="cna-pub-venue-detail">2022 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-22966-4_14">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C16</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Chanyang Ju, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
-      <div class="cna-pub-title"><i>Monitoring Provenance of Delegated Personal Data With Blockchain.</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IEEE Blockchain</span>
-      <span class="cna-pub-venue-detail">2022 · acc. 15.3% · <a href="https://ieeexplore.ieee.org/document/9881821">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ECCV</span>
+      <span class="cna-row-aside-detail">2024 · <a href="https://doi.org/10.1007/978-3-031-73013-9_9">DOI</a></span>
     </div>
   </article>
 
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2021</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C15</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Yunseong Jeong, Jinsu Kim, Jungkon Kim, Hyung Tae Lee, and <b>Jae Hong Seo*</b></div>
-      <div class="cna-pub-title"><i>IronMask: Modular Architecture for Protecting Deep Face Template</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C22</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>On the Certifiable Robustness of Face Recognition Systems</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">CVPR</span>
-      <span class="cna-pub-venue-detail">2021 · acc. 23.7% · <a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">CISC-S</span>
+      <span class="cna-row-aside-detail">2024</span>
     </div>
   </article>
 
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2017</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C14</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Yohei Watanabe, Keita Emura, and <b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>New Revocable IBE in Prime-Order Groups: Adaptively Secure, Decryption Key Exposure Resistant, and with Short Public Parameters</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C21</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+      <div class="cna-row-sub"><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">CT-RSA</span>
-      <span class="cna-pub-venue-detail">2017 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-52153-4_25">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IEEE ICBC</span>
+      <span class="cna-row-aside-detail">2024 · <a href="https://ieeexplore.ieee.org/document/10634378">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C20</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IEEE S&amp;P</span>
+      <span class="cna-row-aside-detail">2024 · <a href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2015</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2023</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C13</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Adaptive-ID Secure Revocable Hierarchical Identity-Based Encryption</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C19</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IWSEC</span>
-      <span class="cna-pub-venue-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-22425-1_2">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">BMVC (Oral)</span>
+      <span class="cna-row-aside-detail">2023 · <a href="https://papers.bmvc2023.org/0535.pdf">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C12</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
-      <div class="cna-pub-title"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C18</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>TENET : Sublogarithmic Proof and Sublinear Verifier Inner Product Argument without a Trusted Setup.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ACNS</span>
-      <span class="cna-pub-venue-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-28166-7_10">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C11</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable Hierarchical Identity-Based Encryption: History-Free Update, Security Against Insiders, and Short Ciphertexts</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">CT-RSA</span>
-      <span class="cna-pub-venue-detail">2015 · acc. 23.4% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-16715-2_6">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IWSEC</span>
+      <span class="cna-row-aside-detail">2023 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-41326-1_12">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2014</h3><span class="cna-pubs-year-count">2 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2022</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C10</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Jung Hee Cheon, Hyung Tae Lee, and <b>Jae Hong Seo</b>; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>A New Additive Homomorphic Encryption based on the co-ACD Problem</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C17</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">ACM CCS</span>
-      <span class="cna-pub-venue-detail">2014 · acc. 19.5% · <a href="https://dl.acm.org/doi/10.1145/2660267.2660335">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-ASIACRYPT</span>
+      <span class="cna-row-aside-detail">2022 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-22966-4_14">DOI</a></span>
     </div>
   </article>
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C9</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Hyung Tae Lee and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Security Analysis of Multilinear Maps over the Integers</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C16</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Chanyang Ju, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+      <div class="cna-row-sub"><i>Monitoring Provenance of Delegated Personal Data With Blockchain.</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-CRYPTO</span>
-      <span class="cna-pub-venue-detail">2014 · acc. 26% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-662-44371-2_13">DOI</a></span>
-    </div>
-  </article>
-
-  </div>
-</details>
-
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2013</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C8</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors">Florian Böhl, Dennis Hofheinz, Tibor Jager, Jessica Koch, <b>Jae Hong Seo</b>, and Christoph Striecks; [alphabetical order]</div>
-      <div class="cna-pub-title"><i>Practical Signatures from Standard Assumptions</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-EUROCRYPT</span>
-      <span class="cna-pub-venue-detail">2013 · acc. 20% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-38348-9_28">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C7</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Revocable Identity-Based Encryption, Revisited: Security Definition and Construction</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
-      <span class="cna-pub-venue-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/016">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C6</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
-      <div class="cna-pub-title"><i>Efficient Delegation of Key Generation and Revocation Functionalities in Identity-Based Encryption</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">CT-RSA</span>
-      <span class="cna-pub-venue-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/018">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IEEE Blockchain</span>
+      <span class="cna-row-aside-detail">2022 · acc. 15.3% · <a href="https://ieeexplore.ieee.org/document/9881821">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2012</h3><span class="cna-pubs-year-count">3 papers</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2021</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C5</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>On the (Im)possibility of Projecting Property in Prime-Order Setting</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C15</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Sunpill Kim</b>, Yunseong Jeong, Jinsu Kim, Jungkon Kim, Hyung Tae Lee, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>IronMask: Modular Architecture for Protecting Deep Face Template</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-ASIACRYPT</span>
-      <span class="cna-pub-venue-detail">2012 · acc. 17% · <a href="https://eprint.iacr.org/2013/186">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C4</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Jung Hee Cheon, and Jonathan Katz</div>
-      <div class="cna-pub-title"><i>Constant-Round Multi-Party Private Set Union using Reversed Laurent Series</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
-      <span class="cna-pub-venue-detail">2012 · acc. 22% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-30057-8_24">DOI</a></span>
-    </div>
-  </article>
-
-  <article class="cna-pub">
-    <span class="cna-pub-id">C3</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Jung Hee Cheon</div>
-      <div class="cna-pub-title"><i>Beyond the Limitation of Prime-Order Bilinear Groups, and Round Optimal Blind Signatures</i></div>
-    </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-TCC</span>
-      <span class="cna-pub-venue-detail">2012 · acc. 27% · <a href="https://eprint.iacr.org/2012/198">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">CVPR</span>
+      <span class="cna-row-aside-detail">2021 · acc. 23.7% · <a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2011</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2017</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C2</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
-      <div class="cna-pub-title"><i>Round-Efficient Sub-linear Zero-Knowledge Arguments for Linear Algebra</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C14</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Yohei Watanabe, Keita Emura, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>New Revocable IBE in Prime-Order Groups: Adaptively Secure, Decryption Key Exposure Resistant, and with Short Public Parameters</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
-      <span class="cna-pub-venue-detail">2011 · acc. 27% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-19379-8_24">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">CT-RSA</span>
+      <span class="cna-row-aside-detail">2017 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-52153-4_25">DOI</a></span>
     </div>
   </article>
 
   </div>
 </details>
 
-<details class="cna-pubs-year" markdown="0">
-  <summary><h3>2009</h3><span class="cna-pubs-year-count">1 paper</span></summary>
-  <div class="cna-pubs-list">
+<details class="cna-year" markdown="0">
+  <summary><h3>2015</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
 
-  <article class="cna-pub">
-    <span class="cna-pub-id">C1</span>
-    <div class="cna-pub-main">
-      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
-      <div class="cna-pub-title"><i>Anonymous Hierarchical Identity-Based Encryption with Constant Size Ciphertexts</i></div>
+  <article class="cna-row">
+    <span class="cna-row-meta">C13</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Adaptive-ID Secure Revocable Hierarchical Identity-Based Encryption</i></div>
     </div>
-    <div class="cna-pub-venue">
-      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
-      <span class="cna-pub-venue-detail">2009 · acc. 25% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-00468-1_13">DOI</a></span>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IWSEC</span>
+      <span class="cna-row-aside-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-22425-1_2">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C12</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
+      <div class="cna-row-sub"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ACNS</span>
+      <span class="cna-row-aside-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-28166-7_10">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C11</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable Hierarchical Identity-Based Encryption: History-Free Update, Security Against Insiders, and Short Ciphertexts</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">CT-RSA</span>
+      <span class="cna-row-aside-detail">2015 · acc. 23.4% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-16715-2_6">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2014</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C10</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Jung Hee Cheon, Hyung Tae Lee, and <b>Jae Hong Seo</b>; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>A New Additive Homomorphic Encryption based on the co-ACD Problem</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">ACM CCS</span>
+      <span class="cna-row-aside-detail">2014 · acc. 19.5% · <a href="https://dl.acm.org/doi/10.1145/2660267.2660335">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C9</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Hyung Tae Lee and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Security Analysis of Multilinear Maps over the Integers</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-CRYPTO</span>
+      <span class="cna-row-aside-detail">2014 · acc. 26% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-662-44371-2_13">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2013</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C8</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Florian Böhl, Dennis Hofheinz, Tibor Jager, Jessica Koch, <b>Jae Hong Seo</b>, and Christoph Striecks; [alphabetical order]</div>
+      <div class="cna-row-sub"><i>Practical Signatures from Standard Assumptions</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-EUROCRYPT</span>
+      <span class="cna-row-aside-detail">2013 · acc. 20% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-38348-9_28">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C7</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Revocable Identity-Based Encryption, Revisited: Security Definition and Construction</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-PKC</span>
+      <span class="cna-row-aside-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/016">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C6</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-row-sub"><i>Efficient Delegation of Key Generation and Revocation Functionalities in Identity-Based Encryption</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">CT-RSA</span>
+      <span class="cna-row-aside-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/018">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2012</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C5</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>On the (Im)possibility of Projecting Property in Prime-Order Setting</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-ASIACRYPT</span>
+      <span class="cna-row-aside-detail">2012 · acc. 17% · <a href="https://eprint.iacr.org/2013/186">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C4</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, Jung Hee Cheon, and Jonathan Katz</div>
+      <div class="cna-row-sub"><i>Constant-Round Multi-Party Private Set Union using Reversed Laurent Series</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-PKC</span>
+      <span class="cna-row-aside-detail">2012 · acc. 22% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-30057-8_24">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C3</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b> and Jung Hee Cheon</div>
+      <div class="cna-row-sub"><i>Beyond the Limitation of Prime-Order Bilinear Groups, and Round Optimal Blind Signatures</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-TCC</span>
+      <span class="cna-row-aside-detail">2012 · acc. 27% · <a href="https://eprint.iacr.org/2012/198">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2011</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C2</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub"><i>Round-Efficient Sub-linear Zero-Knowledge Arguments for Linear Algebra</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-PKC</span>
+      <span class="cna-row-aside-detail">2011 · acc. 27% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-19379-8_24">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary><h3>2009</h3><span class="cna-year-count">1 paper</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">C1</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
+      <div class="cna-row-sub"><i>Anonymous Hierarchical Identity-Based Encryption with Constant Size Ciphertexts</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-talk">IACR-PKC</span>
+      <span class="cna-row-aside-detail">2009 · acc. 25% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-00468-1_13">DOI</a></span>
     </div>
   </article>
 

--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -10,577 +10,1083 @@ header:
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
 
+<style type="text/css">
+.cna-pubs-counter{
+  display:flex; flex-wrap:wrap; align-items:center; gap:8px;
+  margin:8px 0 24px; padding:14px 18px;
+  background:#fafaf6; border:1px solid #e6e2d8; border-radius:12px;
+  font-size:13.5px;
+}
+.cna-pubs-counter-label{ font-weight:600; color:#52575f; letter-spacing:.02em; margin-right:6px; }
+.cna-pubs-tally{
+  font-size:12px; font-weight:600; letter-spacing:.06em;
+  padding:4px 10px; border-radius:999px; white-space:nowrap;
+  background:#eaf1fa; color:#2b5285;
+}
+
+.cna-pubs-year{
+  border:1px solid #e6e2d8; border-radius:14px;
+  margin:0 0 12px; padding:0;
+  background:#fff;
+  box-shadow:0 1px 2px rgba(31,34,39,.04);
+}
+.cna-pubs-year > summary{
+  cursor:pointer; user-select:none; list-style:none;
+  display:flex; align-items:baseline; justify-content:space-between;
+  gap:12px; padding:14px 18px;
+  border-radius:14px;
+  transition:background .15s ease;
+}
+.cna-pubs-year > summary::-webkit-details-marker{ display:none; }
+.cna-pubs-year > summary:hover{ background:rgba(0,0,0,.025); }
+.cna-pubs-year > summary h3{
+  margin:0; padding:0; border:none;
+  font-size:1.2rem; font-weight:600; color:#1f2227;
+}
+.cna-pubs-year-count{ font-size:13px; color:#8a909a; }
+.cna-pubs-year[open] > summary{ border-bottom:1px solid #f0ecdf; border-radius:14px 14px 0 0; }
+.cna-pubs-year > .cna-pubs-list{ padding:8px 18px 14px; }
+
+.cna-pub{
+  display:grid;
+  grid-template-columns:46px 1fr 200px;
+  gap:14px; align-items:start;
+  padding:14px 0;
+  border-bottom:1px solid #f4f0e2;
+}
+.cna-pubs-list .cna-pub:last-child{ border-bottom:none; }
+
+.cna-pub-id{
+  font-size:11.5px; font-weight:700; letter-spacing:.04em;
+  color:#8a909a; padding-top:3px;
+}
+.cna-pub-main{ min-width:0; }
+.cna-pub-authors{ font-size:14.5px; color:#1f2227; line-height:1.5; }
+.cna-pub-title{ font-size:14.5px; color:#52575f; line-height:1.5; margin-top:3px; }
+.cna-pub-title i{ color:#1f2227; }
+
+.cna-pub-venue{
+  display:flex; flex-direction:column; align-items:flex-end; gap:6px;
+  font-size:12px;
+}
+.cna-venue-chip{
+  font-size:11px; font-weight:600; letter-spacing:.06em;
+  padding:4px 10px; border-radius:999px; white-space:nowrap;
+  text-align:center;
+}
+.cna-venue-chip.cna-red  { background:#fbe7eb; color:#b6102d; }
+.cna-venue-chip.cna-blue { background:#eaf1fa; color:#2b5285; }
+.cna-pub-venue-detail{ color:#8a909a; font-size:11.5px; text-align:right; }
+.cna-pub-venue-detail a{ color:#52575f; }
+
+@media (max-width:760px){
+  .cna-pub{ grid-template-columns:36px 1fr; }
+  .cna-pub-venue{ grid-column:2; align-items:flex-start; flex-direction:row; flex-wrap:wrap; gap:8px; }
+  .cna-pub-venue-detail{ text-align:left; }
+}
+</style>
+
+<div class="cna-pubs-counter" markdown="0">
+  <span class="cna-pubs-counter-label">Highlights</span>
+  <span class="cna-pubs-tally">CCS × 2</span>
+  <span class="cna-pubs-tally">S&amp;P × 1</span>
+  <span class="cna-pubs-tally">NDSS × 1</span>
+  <span class="cna-pubs-tally">CVPR × 1</span>
+  <span class="cna-pubs-tally">ICCV × 1</span>
+  <span class="cna-pubs-tally">ECCV × 1</span>
+  <span class="cna-pubs-tally">NeurIPS × 1</span>
+  <span class="cna-pubs-tally">CRYPTO × 1</span>
+  <span class="cna-pubs-tally">EUROCRYPT × 1</span>
+  <span class="cna-pubs-tally">ASIACRYPT × 2</span>
+  <span class="cna-pubs-tally">J. Cryptology × 1</span>
+</div>
+
 ## Journal
 
-<ul type="none">
-<li>
-[J34]  <b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i> 
-        <br>
-        IEEE Access, (TBA)
-    </p>
-</li> 
-<li>
-[J33]  <b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i> 
-        <br>
-        IEEE Access, (TBA)
-    </p>
-</li> 
-<li>
-[J32]  <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo*</b>
-    <p>
-        <i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i> 
-        <br>
-        IEEE Access, (<A href="https://ieeexplore.ieee.org/abstract/document/11316118">DOI</A>)
-    </p>
-</li> 
-<li>
-[J31]  <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i> 
-        <br>
-        IEEE Transactions on Biometrics, Behavior, and Identity Science, (<A href="https://doi.org/10.1109/TBIOM.2025.3644396">DOI</A>)
-    </p>
-</li> 
-<li>
-[J30]  <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i> 
-        <br>
-        IEEE Transactions on Dependable and Secure Computing, (<A href="https://ieeexplore.ieee.org/document/11269699">DOI</A>)
-    </p>
-</li> 
-<li>
-[J29]  <b>Sunpill Kim</b>, Hoyong Shin and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Deep Face Template Protection in the Wild</i> 
-        <br>
-        Pattern Recognition, Apr 2025. (<A href="https://doi.org/10.1016/j.patcog.2024.111336">DOI</A>)
-    </p>
-</li>  
-<li>
-[J28]  Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung
-    <p>
-        <i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i> 
-        <br>
-        IEEE Transactions on Dependable and Secure Computing, Feb 2024. (<A href="https://ieeexplore.ieee.org/document/10420492">DOI</A>)
-    </p>
-</li>  
-<li>
-[J27]  Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Leopard: Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption.</i> 
-        <br>
-        IEEE Transactions on Information Forensics and Security, August 2023. (<A href="https://ieeexplore.ieee.org/document/10198341">DOI</A>)
-    </p>
-</li>
-<li>  
-[J26]  Hyung Tae Lee and <b>Jae Hong Seo*</b>
-    <p>
-        <i>On the Security of Functional Encryption in the Generic Group Model.</i> 
-        <br>
-        Designs, Codes and Cryptography, May 2023.  (<A href="https://doi.org/10.1007/s10623-023-01237-1">DOI</A>)
-    </p>
-</li>   
-<li>
-  
-[J25]  <b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Analysis on Secure Triplet Loss.</i> 
-        <br>
-        IEEE Access, Vol.10, pp 124355--124362  Novemver 2022. (<A href="https://ieeexplore.ieee.org/document/9965373">DOI</A>)
-    </p>
-</li>  
-  
-<li>
-[J24]  <b>Heewon Chung</b>, Kyoohyung Han, Chanyang Ju, Myungsun Kim, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger.</i> 
-        <br>
-        IEEE Access, April 2022. (<A href="https://ieeexplore.ieee.org/document/9758733">DOI</A>)
-    </p>
-</li>
-  
-<li>
-[J23]  Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, <b>Jae Hong Seo</b>, and Sungwook Kim*
-    <p>
-        <i>Efficient Sum-Check Protocol for Convolution.</i> 
-        <br>
-        IEEE Access,  Vol. 9, pp 164047--164059, December 2021. (<A href="https://ieeexplore.ieee.org/document/9638642">DOI</A>)
-    </p>
-</li>
+<details class="cna-pubs-year" open markdown="0">
+  <summary><h3>2026</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-[J22]  Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Analysis of Zero-Knowledge Protocols for Verifiable Computation and Its Applications(연산을 검증하기 위한 영지식 증명 프로토콜의 기법 및 응용 사례 분석).</i> 
-        <br>
-        Journal of the Korea Institute of Information Security & Cryptology(정보보호학회논문지),  Vol. 31, pp 675--686, 2021. (<A href="https://www.dbpia.co.kr/pdf/pdfView.do?nodeId=NODE10596717">DOI</A>)
-    </p>
-</li>  
-  
-<li>
-[J21]  Keita Emura, <b>Jae Hong Seo</b>, and Yohei Watanabe*
-    <p>
-        <i>Efficient revocable identity-based encryption with short public parameters.</i> 
-        <br>
-        Theoretical Computer Science,  Vol. 863, pp 127--155, April 2021. (<A href="https://www.sciencedirect.com/science/article/pii/S0304397521001134">DOI</A>)
-    </p>
-</li>
-    
-<li>
-[J20]  Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, Huaxiong Wang, and Taek-Young Youn
-    <p>
-        <i>Public key encryption with equality test in the standard model.</i> 
-        <br>
-        Information Sciences,  Vol. 516, pp 89--108, March 2020. (<A href="https://www.sciencedirect.com/science/article/pii/S0020025516322290">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J34</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail">TBA</span>
+    </div>
+  </article>
 
-<li>
-[J19] <b>Jae Hong Seo</b>
-    <p>
-        <i>Efficient Digital Signatures from RSA without Random Oracles</i>
-        <br> 
-        Information Sciences,  Vol. 512, pp 471--480, March 2020 . (<A href="https://www.sciencedirect.com/science/article/pii/S0020025519309478?via%3Dihub">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J33</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail">TBA</span>
+    </div>
+  </article>
 
-<li>
-    [J18] Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]
-    <p>
-        <i>Public Key Encryption with Equality Test from Generic Assumptions in the Random Oracle Model</i>
-        <br>
-        Information Sciences, Vol.500, pp 15--33, 2019. (<A href="https://www.sciencedirect.com/science/article/pii/S002002551930430X?via%3Dihub">DOI</A>)
-    </p>
-</li>
+  </div>
+</details>
 
-<li>
-    [J17] Sungwook Kim, Jinsu Kim, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>A New Approach for Practical Function-Private Inner Product Encryption.</i>
-        <br>
-        Theoretical Computer Science, Vol. 783,  pp 22--40, September 2019. (<A href="https://www.sciencedirect.com/science/article/pii/S0304397519301690?via%3Dihub">DOI</A>)
-    </p>
-</li>
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2025</h3><span class="cna-pubs-year-count">4 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [J16] <b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama
-    <p>
-        <i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures.</i>
-        <br>
-        International Journal of Information Security, Vol.17(2), pp193--220, 2018 (<A href="https://link.springer.com/article/10.1007/s10207-017-0367-z">DOI</A>)
-    </p>
-</li>
-    
-<li>
-    [J15] Jinsu Kim, Sungwook Kim, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>A new Scale-Invariant Homomorphic Encryption Scheme.</i>
-        <br>
-        Information Sciences, Vol.422, pp 177--187, 2018 (<A href="https://www.sciencedirect.com/science/article/pii/S0020025517309313">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J32</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Hyunjung Son</b>, <b>Seunghun Paik</b>, <b>Yunki Kim</b>, <b>Sunpill Kim</b>, Heewon Chung, <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Doubly Efficient Fuzzy Private Set Intersection for High-dimensional Data with Cosine Similarity</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail"><a href="https://ieeexplore.ieee.org/abstract/document/11316118">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J14] <b>Jae Hong Seo</b>
-    <p>
-        <i>Short Signatures from Diffie–Hellman: Realizing Almost Compact Public Key</i>
-        <br>
-        Journal of Cryptology, Volume 30, Issue 3, pp 735--759, July 2017. (<A href="https://link.springer.com/article/10.1007/s00145-016-9234-8">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J31</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Towards Certifiably Robust Face Recognition: Analyses and Improvements</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE TBIOM</span>
+      <span class="cna-pub-venue-detail"><a href="https://doi.org/10.1109/TBIOM.2025.3644396">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J13] Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]
-    <p>
-        <i>Semi-Generic Construction of Public Key Encryption and Identity-Based Encryption with Equality Test</i>
-        <br>
-        Information Sciences, Vol.373, pp 419--440, 2016. (<A href="https://www.sciencedirect.com/science/article/pii/S0020025516307654">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J30</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>On the Reversibility of Locality-Sensitive Hashing-based Biometric Template Protections</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE TDSC</span>
+      <span class="cna-pub-venue-detail"><a href="https://ieeexplore.ieee.org/document/11269699">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J12] Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b> and Huaxiong Wang
-    <p>
-        <i>CCA2 attack and modification of Huang et al.'s public key encryption with authorized equality test</i>
-        <br>
-        The Computer Journal, 59(11), pp 1689--1694, 2016. (<A href="https://ieeexplore.ieee.org/document/8130169">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J29</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Hoyong Shin and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Deep Face Template Protection in the Wild</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Pattern Recognition</span>
+      <span class="cna-pub-venue-detail">Apr 2025 · <a href="https://doi.org/10.1016/j.patcog.2024.111336">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J11] <b>Jae Hong Seo</b> and Keita Emura, 
-    <p>
-        <i>Revocable hierarchical identity-based encryption via history-free approach</i>
-        <br>
-        Theoretical Computer Science, Vol.615,  pp45--60, 2016. (<A href="https://www.sciencedirect.com/science/article/pii/S0304397515011354">DOI</A>)
-    </p>
-</li>
+  </div>
+</details>
 
-<li>
-    [J10] Keita Emura, <b>Jae Hong Seo*</b>, and Taek-Young Youn; [alphabetical order]
-    <p>
-        <i>Semi-generic Transformation of Revocable Hierarchical Identity-Based Encryption and its DBDH Instantiation</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E99-A, No.1, pp83--91, Jan. 2016. (<A href="https://dblp.org/rec/journals/ieicet/EmuraSY16.html">DOI</A>)
-    </p>
-</li>
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2024</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [J9]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>     
-        <i>Revocable Identity-Based Encryption with Rejoin Functionality</i>
-        <br>      
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E97-A, No.8, pp1806--1809, Aug. 2014. (<A href="https://search.ieice.org/bin/summary.php?id=e97-a_8_1806&category=A&year=2014&lang=E&abst=">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J28</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Changhao Chenli, Wenyi Tang, <b>Hyeonbum Lee</b>, and Taeho Jung</div>
+      <div class="cna-pub-title"><i>Fair2Trade: Digital Trading Platform Ensuring Exchange and Distribution Fairness</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE TDSC</span>
+      <span class="cna-pub-venue-detail">Feb 2024 · <a href="https://ieeexplore.ieee.org/document/10420492">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J8]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Revocable Identity-Based Cryptosystem Revisited: Security Models and Constructions</i>
-        <br>
-        IEEE Transactions on Information Forensics and Security, Vol.9(7), pp1193--1205, 2014. (<A href="https://ieeexplore.ieee.org/document/6824197?arnumber=6824197">DOI</A>) 
-    </p>
-</li>
+  </div>
+</details>
 
-<li>
-    [J7]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Revocable Hierarchical Identity-Based Encryption</i>
-        <br>
-        Theoretical Computer Science,Vol.542, pp44--62, 2014. (<A href="https://www.sciencedirect.com/science/article/pii/S0304397514003363?via%3Dihub">DOI</A>)
-    </p>
-</li>
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2023</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [J6]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>A Remark on "Efficient Revocable ID-Based Encryption with a Public Channel"</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E96-A, No.11, pp2282--2285, Nov. 2013. (<A href="https://www.jstage.jst.go.jp/article/transfun/E96.A/11/E96.A_2282/_article">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J27</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Sungwook Kim, <b>Hyeonbum Lee</b>, <b>Gwangwoon Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Leopard: Sublinear Verifier Inner Product Argument under Discrete Logarithm Assumption.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE TIFS</span>
+      <span class="cna-pub-venue-detail">Aug 2023 · <a href="https://ieeexplore.ieee.org/document/10198341">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J5]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>On Discrete Logarithm based Additively Homomorphic Encryption</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E96-A, No.11, pp. 2286--2289, Nov. 2013. (<A href="https://search.ieice.org/bin/summary.php?id=e96-a_11_2286&category=A&year=2013&lang=E&abst=">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J26</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>On the Security of Functional Encryption in the Generic Group Model.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Designs, Codes &amp; Crypto.</span>
+      <span class="cna-pub-venue-detail">May 2023 · <a href="https://doi.org/10.1007/s10623-023-01237-1">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J4]  Jung Hee Cheon, Stanislaw Jarecki, and <b>Jae Hong Seo*</b>; [alphabetical order]
-    <p>
-        <i>Multi-Party Privacy-Preserving Set Intersection with Quasi-linear Complexity</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E95-A, No.8, pp.1366--1378, Aug. 2012. (<A href="https://search.ieice.org/bin/summary.php?id=e95-a_8_1366&category=A&year=2012&lang=E&abst=">DOI</A>)
-    </p>
-</li>
+  </div>
+</details>
 
-<li>
-    [J3]  <b>Jae Hong Seo</b>
-    <p>
-        <i>Short Round Sub-linear Zero-Knowledge Argument for  Linear Algebraic Relations</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E95-A, No.4, pp.776--789, Apr. 2012. (<A href="https://search.ieice.org/bin/summary.php?id=e95-a_4_776&category=A&year=2012&lang=E&abst=">DOI</A>)
-    </p>
-</li>
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2022</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [J2]  <b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki
-    <p>
-        <i>Anonymous Hierarchical Identity-Based Encryption with Short Ciphertexts</i>
-        <br>
-        IEICE transactions on Fundamentals of Electronics, Communications and Computer Sciences, Vol.E94-A, No.1, pp.45--56, Jan. 2011. (<A href="https://search.ieice.org/bin/summary.php?id=e94-a_1_45&category=A&year=2011&lang=E&abst=">DOI</A>)
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J25</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Bora Jeong</b>, <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Analysis on Secure Triplet Loss.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail">Nov 2022 · <a href="https://ieeexplore.ieee.org/document/9965373">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-    [J1]  <b>Jae Hong Seo</b>, HyoJin Yoon, Seongan Lim, Jung Hee Cheon, and Dowon Hong
-    <p>
-        <i>Analysis of Privacy-Preserving Element Reduction of a Multiset</i>
-        <br>
-        Journal of the Korean Mathematical Society, Vol.46, No.1, pp.59--69, 2009. (<A href="http://koreascience.or.kr/article/JAKO200907841290235.page">DOI</A>)
-    </p>
-</li>
-</ul>
+  <article class="cna-pub">
+    <span class="cna-pub-id">J24</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Heewon Chung</b>, Kyoohyung Han, Chanyang Ju, Myungsun Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Bulletproofs+: Shorter Proofs for a Privacy-Enhanced Distributed Ledger.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail">Apr 2022 · <a href="https://ieeexplore.ieee.org/document/9758733">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2021</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J23</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, <b>Jae Hong Seo</b>, and Sungwook Kim*</div>
+      <div class="cna-pub-title"><i>Efficient Sum-Check Protocol for Convolution.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE Access</span>
+      <span class="cna-pub-venue-detail">Dec 2021 · <a href="https://ieeexplore.ieee.org/document/9638642">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J22</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Chanyang Ju, <b>Hyeonbum Lee</b>, <b>Heewon Chung</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Analysis of Zero-Knowledge Protocols for Verifiable Computation and Its Applications (연산을 검증하기 위한 영지식 증명 프로토콜의 기법 및 응용 사례 분석).</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">KIISC 정보보호학회논문지</span>
+      <span class="cna-pub-venue-detail">2021 · <a href="https://www.dbpia.co.kr/pdf/pdfView.do?nodeId=NODE10596717">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J21</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Keita Emura, <b>Jae Hong Seo</b>, and Yohei Watanabe*</div>
+      <div class="cna-pub-title"><i>Efficient revocable identity-based encryption with short public parameters.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
+      <span class="cna-pub-venue-detail">Apr 2021 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397521001134">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2020</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J20</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, Huaxiong Wang, and Taek-Young Youn</div>
+      <div class="cna-pub-title"><i>Public key encryption with equality test in the standard model.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Information Sciences</span>
+      <span class="cna-pub-venue-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516322290">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J19</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>Efficient Digital Signatures from RSA without Random Oracles</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Information Sciences</span>
+      <span class="cna-pub-venue-detail">Mar 2020 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025519309478?via%3Dihub">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2019</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J18</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Public Key Encryption with Equality Test from Generic Assumptions in the Random Oracle Model</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Information Sciences</span>
+      <span class="cna-pub-venue-detail">2019 · <a href="https://www.sciencedirect.com/science/article/pii/S002002551930430X?via%3Dihub">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J17</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Sungwook Kim, Jinsu Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>A New Approach for Practical Function-Private Inner Product Encryption.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
+      <span class="cna-pub-venue-detail">Sep 2019 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397519301690?via%3Dihub">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2018</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J16</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
+      <div class="cna-pub-title"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Int. J. Info. Security</span>
+      <span class="cna-pub-venue-detail">2018 · <a href="https://link.springer.com/article/10.1007/s10207-017-0367-z">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J15</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Jinsu Kim, Sungwook Kim, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>A new Scale-Invariant Homomorphic Encryption Scheme.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Information Sciences</span>
+      <span class="cna-pub-venue-detail">2018 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025517309313">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2017</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J14</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>Short Signatures from Diffie–Hellman: Realizing Almost Compact Public Key</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">J. Cryptology</span>
+      <span class="cna-pub-venue-detail">Jul 2017 · <a href="https://link.springer.com/article/10.1007/s00145-016-9234-8">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2016</h3><span class="cna-pubs-year-count">4 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J13</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b>, and Huaxiong Wang; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Semi-Generic Construction of Public Key Encryption and Identity-Based Encryption with Equality Test</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Information Sciences</span>
+      <span class="cna-pub-venue-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0020025516307654">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J12</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee, San Ling, <b>Jae Hong Seo*</b> and Huaxiong Wang</div>
+      <div class="cna-pub-title"><i>CCA2 attack and modification of Huang et al.'s public key encryption with authorized equality test</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">The Computer Journal</span>
+      <span class="cna-pub-venue-detail">2016 · <a href="https://ieeexplore.ieee.org/document/8130169">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J11</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable hierarchical identity-based encryption via history-free approach</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
+      <span class="cna-pub-venue-detail">2016 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397515011354">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J10</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Keita Emura, <b>Jae Hong Seo*</b>, and Taek-Young Youn; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Semi-generic Transformation of Revocable Hierarchical Identity-Based Encryption and its DBDH Instantiation</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Jan 2016 · <a href="https://dblp.org/rec/journals/ieicet/EmuraSY16.html">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2014</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J9</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable Identity-Based Encryption with Rejoin Functionality</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Aug 2014 · <a href="https://search.ieice.org/bin/summary.php?id=e97-a_8_1806&category=A&year=2014&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J8</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable Identity-Based Cryptosystem Revisited: Security Models and Constructions</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEEE TIFS</span>
+      <span class="cna-pub-venue-detail">2014 · <a href="https://ieeexplore.ieee.org/document/6824197?arnumber=6824197">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J7</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable Hierarchical Identity-Based Encryption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">Theor. Computer Science</span>
+      <span class="cna-pub-venue-detail">2014 · <a href="https://www.sciencedirect.com/science/article/pii/S0304397514003363?via%3Dihub">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2013</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J6</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>A Remark on "Efficient Revocable ID-Based Encryption with a Public Channel"</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Nov 2013 · <a href="https://www.jstage.jst.go.jp/article/transfun/E96.A/11/E96.A_2282/_article">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J5</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>On Discrete Logarithm based Additively Homomorphic Encryption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Nov 2013 · <a href="https://search.ieice.org/bin/summary.php?id=e96-a_11_2286&category=A&year=2013&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2012</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J4</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Jung Hee Cheon, Stanislaw Jarecki, and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Multi-Party Privacy-Preserving Set Intersection with Quasi-linear Complexity</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Aug 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_8_1366&category=A&year=2012&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J3</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>Short Round Sub-linear Zero-Knowledge Argument for Linear Algebraic Relations</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Apr 2012 · <a href="https://search.ieice.org/bin/summary.php?id=e95-a_4_776&category=A&year=2012&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2011</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J2</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
+      <div class="cna-pub-title"><i>Anonymous Hierarchical Identity-Based Encryption with Short Ciphertexts</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">IEICE Trans. Fundamentals</span>
+      <span class="cna-pub-venue-detail">Jan 2011 · <a href="https://search.ieice.org/bin/summary.php?id=e94-a_1_45&category=A&year=2011&lang=E&abst=">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2009</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">J1</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, HyoJin Yoon, Seongan Lim, Jung Hee Cheon, and Dowon Hong</div>
+      <div class="cna-pub-title"><i>Analysis of Privacy-Preserving Element Reduction of a Multiset</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-red">J. Korean Math. Soc.</span>
+      <span class="cna-pub-venue-detail">2009 · <a href="http://koreascience.or.kr/article/JAKO200907841290235.page">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
 
 ## Conference
 
-<ul type="none">
-<li> 
-  [C31] <b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i> 
-          <br>
-          <b>CCS</b> 2026, (TBA)
-      </p>  
-</li>
-<li> 
-  [C30] <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo*</b>, and Taeho Jung* 
-      <p>
-          <i>Scalable Private Set Intersection over Distributed Encrypted Data</i> 
-          <br>
-          <b>ASIACCS</b> 2026, (TBA)
-      </p>  
-</li>
-<li> 
-  [C29] Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung
-      <p>
-          <i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i> 
-          <br>
-          <b>NDSS</b> 2026, (TBA)
-      </p>  
-</li>
-<li> 
-  [C28] <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>Non-Adaptive Adversarial Face Generation</i> 
-          <br>
-          <b>NeurIPS</b> 2025, (TBA)
-      </p>  
-</li>
-<li> 
-  [C27] <b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>A Survey of Model Inversion Attacks on Image Domain</i> 
-          <br>
-          <b>ICTC</b> 2025, (<A href="https://ieeexplore.ieee.org/abstract/document/11388195">DOI</A>)
-      </p>  
-</li>
-<li> 
-  [C26] <b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>A Survey on Fuzzy Private Set Intersection Protocols</i> 
-          <br>
-          <b>ICTC</b> 2025, (<A href="https://ieeexplore.ieee.org/abstract/document/11388448">DOI</A>)
-      </p>  
-</li>
-<li> 
-  [C25] <b>Sunpill Kim &dagger;</b>, <b>Seunghun Paik &dagger;</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>IDFace: Face Template Protection for Secure and Efficient Identification</i> 
-          <br>
-          <b>ICCV</b> 2025, (<A href="https://openaccess.thecvf.com/content/ICCV2025/html/Kim_IDFace_Face_Template_Protection_for_Efficient_and_Secure_Identification_ICCV_2025_paper.html">DOI</A>)
-      </p>  
-</li>  
-<li> 
-  [C24] Jaehwan Park&dagger;, <b>Hyeonbum Lee&dagger;</b>, Junbeom Hur, <b>Jae Hong Seo*</b> and Doowon Kim*
-      <p>
-          <i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i> 
-          <br>
-          <b>ESORICS</b> 2025, (<A href="https://link.springer.com/chapter/10.1007/978-3-032-07891-9_17">DOI</A>)
-      </p>  
-</li>  
-<li> 
-  [C23] <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b>
-      <p>
-          <i>Towards Certifiably Robust Face Recognition</i> 
-          <br>
-          <b>ECCV</b> 2024, (<A href="https://doi.org/10.1007/978-3-031-73013-9_9">DOI</A>)
-      </p>  
-</li>  
-<li> 
-  [C22] <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b>
-      <p>
-          <i>On the Certifiable Robustness of Face Recognition Systems</i> 
-          <br>
-          <b>CISC-S</b> 2024
-      </p>  
-</li>   
-<li> 
-  [C21] <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung
-      <p>
-          <i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i> 
-          <br>
-          <b>IEEE ICBC</b> 2024, (<A href="https://ieeexplore.ieee.org/document/10634378">DOI</A>)
-      </p>  
-</li> 
-<li> 
-  [C20]  <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i> 
-          <br>
-          <b>IEEE S&P</b> 2024, (<A href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</A>)
-      </p>  
-</li>  
-<li> 
-  [C19]  <b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes.</i> 
-          <br>
-          <b>BMVC</b> 2023 (Oral), (<A href="https://papers.bmvc2023.org/0535.pdf">DOI</A>)
-      </p>  
-</li> 
-<li> 
-  [C18]  <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b>
-      <p>
-          <i>TENET : Sublogarithmic Proof and Sublinear Verifier Inner Product Argument without a Trusted Setup.</i> 
-          <br>
-           <b>IWSEC</b> 2023, (<A href="https://link.springer.com/chapter/10.1007/978-3-031-41326-1_12">DOI</A>)
-      </p>
-  </li>   
-<li>
-    [C17] Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i> 
-        <br>
-        <b>IACR-ASIACRYPT</b> 2022, (<A href="https://link.springer.com/chapter/10.1007/978-3-031-22966-4_14">DOI</A>)
-    </p>
-</li>    
-<li>
-    [C16] Chanyang Ju, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung
-    <p>
-        <i>Monitoring Provenance of Delegated Personal Data With Blockchain.</i> 
-        <br>
-        <b>IEEE Blockchain</b> 2022, (<A href="https://ieeexplore.ieee.org/document/9881821">DOI</A>) (acceptance rate = 15.3%).
-    </p>
-</li>   
-<li>
-    [C15] <b>Sunpill Kim</b>, Yunseong Jeong, Jinsu Kim, Jungkon Kim, Hyung Tae Lee, and <b>Jae Hong Seo*</b>
-    <p>
-        <i>IronMask: Modular Architecture for Protecting Deep Face Template</i>
-        <br>
-        <b>CVPR</b> 2021, (<A href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">DOI</A>) (acceptance rate = 23.7%).
-    </p>
-</li>
+<details class="cna-pubs-year" open markdown="0">
+  <summary><h3>2026</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [C14] Yohei Watanabe, Keita Emura, and <b>Jae Hong Seo</b>
-    <p>
-        <i>New Revocable IBE in Prime-Order Groups: Adaptively Secure, Decryption Key Exposure Resistant, and with Short Public Parameters</i>
-        <br>
-        <b>CT-RSA</b> 2017, (<A href="https://link.springer.com/chapter/10.1007%2F978-3-319-52153-4_25">DOI</A>).
-    </p>
-</li>
-    
-<li>
-    [C13] <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Adaptive-ID Secure Revocable Hierarchical Identity-Based Encryption</i>
-        <br>
-        <b>IWSEC</b> 2015, (<A href="https://link.springer.com/chapter/10.1007%2F978-3-319-22425-1_2">DOI</A>).
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C31</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ACM CCS</span>
+      <span class="cna-pub-venue-detail">2026 · TBA</span>
+    </div>
+  </article>
 
-<li>
-    [C12] <b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama
-    <p>
-        <i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures</i>
-        <br>
-        <b>ACNS</b> 2015, (<A href="https://link.springer.com/chapter/10.1007%2F978-3-319-28166-7_10">DOI</A>).
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C30</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo*</b>, and Taeho Jung*</div>
+      <div class="cna-pub-title"><i>Scalable Private Set Intersection over Distributed Encrypted Data</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ASIACCS</span>
+      <span class="cna-pub-venue-detail">2026 · TBA</span>
+    </div>
+  </article>
 
-<li>
-    [C11] <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Revocable Hierarchical Identity-Based Encryption: History-Free Update, Security Against Insiders, and Short Ciphertexts</i>
-        <br>
-        <b>CT-RSA</b> 2015, (<A href="https://link.springer.com/chapter/10.1007%2F978-3-319-16715-2_6">DOI</A>) (acceptance rate = 23.4%).
-    </p>
-</li>
-<li>
-    [C10] Jung Hee Cheon, Hyung Tae Lee, and <b>Jae Hong Seo</b>; [alphabetical order]
-    <p>
-        <i>A New Additive Homomorphic Encryption based on the co-ACD Problem</i>
-        <br>
-        <b>ACM-CCS</b> 2014, (<A href="https://dl.acm.org/doi/10.1145/2660267.2660335">DOI</A>) (acceptance rate = 19.5%). 
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C29</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Nirajan Koirala, <b>Seunghun Paik</b>, Sam Martin, Helena Berens, Tasha Januszewicz, Jonathan Takeshita, <b>Jae Hong Seo</b>, Taeho Jung</div>
+      <div class="cna-pub-title"><i>Select-Then-Compute: Encrypted Label Selection and Analytics over Distributed Datasets using FHE</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">NDSS</span>
+      <span class="cna-pub-venue-detail">2026 · TBA</span>
+    </div>
+  </article>
 
-<li>
-    [C9]  Hyung Tae Lee and <b>Jae Hong Seo*</b>; [alphabetical order]
-    <p>
-        <i>Security Analysis of Multilinear Maps over the Integers</i>
-        <br>
-        <b>IACR-CRYPTO</b> 2014, (<A href="https://link.springer.com/chapter/10.1007%2F978-3-662-44371-2_13">DOI</A>) (acceptance rate = 26%). 
-    </p>
-</li>
+  </div>
+</details>
 
-<li>
-    [C8]  Florian Böhl, Dennis Hofheinz, Tibor Jager, Jessica Koch, <b>Jae Hong Seo</b>, and Christoph Striecks; [alphabetical order]
-    <p>
-        <i>Practical Signatures from Standard Assumptions</i>
-        <br>
-        <b>IACR-EUROCRYPT</b> 2013, (<A href="https://link.springer.com/chapter/10.1007/978-3-642-38348-9_28">DOI</A>) (acceptance rate = 20%).
-    </p>
-</li>
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2025</h3><span class="cna-pubs-year-count">5 papers</span></summary>
+  <div class="cna-pubs-list">
 
-<li>
-    [C7]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Revocable Identity-Based Encryption, Revisited: Security Definition and Construction</i>
-        <br>
-        <b>IACR-PKC</b> 2013, (<A href="https://eprint.iacr.org/2013/016">DOI</A>) (acceptance rate = 28%).
-    </p>
-</li>
-<li>
-    [C6]  <b>Jae Hong Seo</b> and Keita Emura
-    <p>
-        <i>Efficient Delegation of Key Generation and Revocation Functionalities in Identity-Based Encryption</i>
-        <br>
-        <b>CT-RSA</b> 2013, (<A href="https://eprint.iacr.org/2013/018">DOI</A>) (acceptance rate = 28%).
-    </p>
-</li>
-<li>
-    [C5]  <b>Jae Hong Seo</b>
-    <p>
-        <i>On the (Im)possibility of Projecting Property in Prime-Order Setting</i>
-        <br>
-        <b>IACR-ASIACRYPT</b> 2012, (<A href="https://eprint.iacr.org/2013/186">DOI</A>) (acceptance rate = 17%).
-    </p>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C28</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Non-Adaptive Adversarial Face Generation</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">NeurIPS</span>
+      <span class="cna-pub-venue-detail">2025 · TBA</span>
+    </div>
+  </article>
 
-<li>
-    [C4]  <b>Jae Hong Seo</b>, Jung Hee Cheon, and Jonathan Katz
-    <p>
-        <i>Constant-Round Multi-Party Private Set Union using Reversed Laurent Series</i>
-        <br>          
-        <b>IACR-PKC</b> 2012, (<A href="https://link.springer.com/chapter/10.1007/978-3-642-30057-8_24">DOI</A>) (acceptance rate = 22%).
-    </p>
-</li>
-<li>
-    [C3]  <b>Jae Hong Seo</b> and Jung Hee Cheon
-    <p>
-        <i>Beyond the Limitation of Prime-Order Bilinear Groups, and Round Optimal Blind Signatures</i>
-        <br>
-        <b>IACR-TCC</b> 2012, (<A href="https://eprint.iacr.org/2012/198">DOI</A>) (acceptance rate = 27%). 
-    </p>
-</li>
-<li>
-    [C2]  <b>Jae Hong Seo</b>
-    <p>
-        <i>Round-Efficient Sub-linear Zero-Knowledge Arguments for Linear Algebra</i>
-        <br>
-        <b>IACR-PKC</b> 2011, (<A href="https://link.springer.com/chapter/10.1007/978-3-642-19379-8_24">DOI</A>) (acceptance rate = 27%). 
-    </p>
-</li>
-<li>
-    [C1]  <b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki
-    <p>
-        <i>Anonymous Hierarchical Identity-Based Encryption with Constant Size Ciphertexts</i>
-        <br>
-        <b>IACR-PKC</b> 2009, (<A href="https://link.springer.com/chapter/10.1007/978-3-642-00468-1_13">DOI</A>) (acceptance rate = 25%). 
-    </p>
-</li>
-</ul>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C27</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Changjin Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>A Survey of Model Inversion Attacks on Image Domain</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ICTC</span>
+      <span class="cna-pub-venue-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388195">DOI</a></span>
+    </div>
+  </article>
 
-### Other
+  <article class="cna-pub">
+    <span class="cna-pub-id">C26</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Yunki Kim</b>, <b>Hyunjung Son</b>, <b>Seunghun Paik</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>A Survey on Fuzzy Private Set Intersection Protocols</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ICTC</span>
+      <span class="cna-pub-venue-detail">2025 · <a href="https://ieeexplore.ieee.org/abstract/document/11388448">DOI</a></span>
+    </div>
+  </article>
 
-<ul type="none">
+  <article class="cna-pub">
+    <span class="cna-pub-id">C25</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Sunpill Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Chanwoo Hwang</b>, <b>Dongsoo Kim</b>, Junbum Shin, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>IDFace: Face Template Protection for Secure and Efficient Identification</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ICCV</span>
+      <span class="cna-pub-venue-detail">2025 · <a href="https://openaccess.thecvf.com/content/ICCV2025/html/Kim_IDFace_Face_Template_Protection_for_Efficient_and_Secure_Identification_ICCV_2025_paper.html">DOI</a></span>
+    </div>
+  </article>
 
-<li>
-</li>
+  <article class="cna-pub">
+    <span class="cna-pub-id">C24</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Jaehwan Park&dagger;, <b>Hyeonbum Lee&dagger;</b>, Junbeom Hur, <b>Jae Hong Seo*</b> and Doowon Kim*</div>
+      <div class="cna-pub-title"><i>UTRA: Universal Token Reusability Attack and Token Unforgeable Delegatable Order-Revealing Encryption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ESORICS</span>
+      <span class="cna-pub-venue-detail">2025 · <a href="https://link.springer.com/chapter/10.1007/978-3-032-07891-9_17">DOI</a></span>
+    </div>
+  </article>
 
-</ul>
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2024</h3><span class="cna-pubs-year-count">4 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C23</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Towards Certifiably Robust Face Recognition</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ECCV</span>
+      <span class="cna-pub-venue-detail">2024 · <a href="https://doi.org/10.1007/978-3-031-73013-9_9">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C22</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>On the Certifiable Robustness of Face Recognition Systems</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">CISC-S</span>
+      <span class="cna-pub-venue-detail">2024</span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C21</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, Wenyi Tang, Shankha Shubhra Mukherjee, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+      <div class="cna-pub-title"><i>PrivHChain: Monitoring the Supply Chain of Controlled Substances with Privacy-Preserving Hierarchical Blockchain</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IEEE ICBC</span>
+      <span class="cna-pub-venue-detail">2024 · <a href="https://ieeexplore.ieee.org/document/10634378">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C20</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Scores Tell Everything about Bob: Non-adaptive Face Reconstruction on Face Recognition Systems</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IEEE S&amp;P</span>
+      <span class="cna-pub-venue-detail">2024 · <a href="https://www.computer.org/csdl/proceedings-article/sp/2024/313000a161/1Ub24A2RzHi">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2023</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C19</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Seunghun Paik</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Security Analysis on Locality-Sensitive Hashing-Based Biometric Template Protection Schemes.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">BMVC (Oral)</span>
+      <span class="cna-pub-venue-detail">2023 · <a href="https://papers.bmvc2023.org/0535.pdf">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C18</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>TENET : Sublogarithmic Proof and Sublinear Verifier Inner Product Argument without a Trusted Setup.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IWSEC</span>
+      <span class="cna-pub-venue-detail">2023 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-41326-1_12">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2022</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C17</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-ASIACRYPT</span>
+      <span class="cna-pub-venue-detail">2022 · <a href="https://link.springer.com/chapter/10.1007/978-3-031-22966-4_14">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C16</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Chanyang Ju, Wenyi Tang, Changhao Chenli, <b>Gwangwoon Lee</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+      <div class="cna-pub-title"><i>Monitoring Provenance of Delegated Personal Data With Blockchain.</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IEEE Blockchain</span>
+      <span class="cna-pub-venue-detail">2022 · acc. 15.3% · <a href="https://ieeexplore.ieee.org/document/9881821">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2021</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C15</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Sunpill Kim</b>, Yunseong Jeong, Jinsu Kim, Jungkon Kim, Hyung Tae Lee, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-pub-title"><i>IronMask: Modular Architecture for Protecting Deep Face Template</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">CVPR</span>
+      <span class="cna-pub-venue-detail">2021 · acc. 23.7% · <a href="https://openaccess.thecvf.com/content/CVPR2021/html/Kim_IronMask_Modular_Architecture_for_Protecting_Deep_Face_Template_CVPR_2021_paper.html">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2017</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C14</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Yohei Watanabe, Keita Emura, and <b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>New Revocable IBE in Prime-Order Groups: Adaptively Secure, Decryption Key Exposure Resistant, and with Short Public Parameters</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">CT-RSA</span>
+      <span class="cna-pub-venue-detail">2017 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-52153-4_25">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2015</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C13</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Adaptive-ID Secure Revocable Hierarchical Identity-Based Encryption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IWSEC</span>
+      <span class="cna-pub-venue-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-22425-1_2">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C12</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Keita Emura, Keita Xagawa, and Kazuki Yoneyama</div>
+      <div class="cna-pub-title"><i>Accumulable Optimistic Fair Exchange from Verifiably Encrypted Homomorphic Signatures</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ACNS</span>
+      <span class="cna-pub-venue-detail">2015 · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-28166-7_10">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C11</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable Hierarchical Identity-Based Encryption: History-Free Update, Security Against Insiders, and Short Ciphertexts</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">CT-RSA</span>
+      <span class="cna-pub-venue-detail">2015 · acc. 23.4% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-319-16715-2_6">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2014</h3><span class="cna-pubs-year-count">2 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C10</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Jung Hee Cheon, Hyung Tae Lee, and <b>Jae Hong Seo</b>; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>A New Additive Homomorphic Encryption based on the co-ACD Problem</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">ACM CCS</span>
+      <span class="cna-pub-venue-detail">2014 · acc. 19.5% · <a href="https://dl.acm.org/doi/10.1145/2660267.2660335">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C9</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Hyung Tae Lee and <b>Jae Hong Seo*</b>; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Security Analysis of Multilinear Maps over the Integers</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-CRYPTO</span>
+      <span class="cna-pub-venue-detail">2014 · acc. 26% · <a href="https://link.springer.com/chapter/10.1007%2F978-3-662-44371-2_13">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2013</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C8</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors">Florian Böhl, Dennis Hofheinz, Tibor Jager, Jessica Koch, <b>Jae Hong Seo</b>, and Christoph Striecks; [alphabetical order]</div>
+      <div class="cna-pub-title"><i>Practical Signatures from Standard Assumptions</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-EUROCRYPT</span>
+      <span class="cna-pub-venue-detail">2013 · acc. 20% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-38348-9_28">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C7</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Revocable Identity-Based Encryption, Revisited: Security Definition and Construction</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
+      <span class="cna-pub-venue-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/016">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C6</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Keita Emura</div>
+      <div class="cna-pub-title"><i>Efficient Delegation of Key Generation and Revocation Functionalities in Identity-Based Encryption</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">CT-RSA</span>
+      <span class="cna-pub-venue-detail">2013 · acc. 28% · <a href="https://eprint.iacr.org/2013/018">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2012</h3><span class="cna-pubs-year-count">3 papers</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C5</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>On the (Im)possibility of Projecting Property in Prime-Order Setting</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-ASIACRYPT</span>
+      <span class="cna-pub-venue-detail">2012 · acc. 17% · <a href="https://eprint.iacr.org/2013/186">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C4</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Jung Hee Cheon, and Jonathan Katz</div>
+      <div class="cna-pub-title"><i>Constant-Round Multi-Party Private Set Union using Reversed Laurent Series</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
+      <span class="cna-pub-venue-detail">2012 · acc. 22% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-30057-8_24">DOI</a></span>
+    </div>
+  </article>
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C3</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b> and Jung Hee Cheon</div>
+      <div class="cna-pub-title"><i>Beyond the Limitation of Prime-Order Bilinear Groups, and Round Optimal Blind Signatures</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-TCC</span>
+      <span class="cna-pub-venue-detail">2012 · acc. 27% · <a href="https://eprint.iacr.org/2012/198">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2011</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C2</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b></div>
+      <div class="cna-pub-title"><i>Round-Efficient Sub-linear Zero-Knowledge Arguments for Linear Algebra</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
+      <span class="cna-pub-venue-detail">2011 · acc. 27% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-19379-8_24">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-pubs-year" markdown="0">
+  <summary><h3>2009</h3><span class="cna-pubs-year-count">1 paper</span></summary>
+  <div class="cna-pubs-list">
+
+  <article class="cna-pub">
+    <span class="cna-pub-id">C1</span>
+    <div class="cna-pub-main">
+      <div class="cna-pub-authors"><b>Jae Hong Seo</b>, Tetsutaro Kobayashi, Miyako Ohkubo, and Koutarou Suzuki</div>
+      <div class="cna-pub-title"><i>Anonymous Hierarchical Identity-Based Encryption with Constant Size Ciphertexts</i></div>
+    </div>
+    <div class="cna-pub-venue">
+      <span class="cna-venue-chip cna-blue">IACR-PKC</span>
+      <span class="cna-pub-venue-detail">2009 · acc. 25% · <a href="https://link.springer.com/chapter/10.1007/978-3-642-00468-1_13">DOI</a></span>
+    </div>
+  </article>
+
+  </div>
+</details>
 
 The corresponding author is marked with *.
 The equal contribution is marked with &dagger;.

--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -10,7 +10,13 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-## Journal
+<nav class="cna-page-toc" aria-label="Section navigation" markdown="0">
+  <span class="cna-page-toc-label">On this page</span>
+  <a class="cna-page-toc-item" href="#journal">Journal</a>
+  <a class="cna-page-toc-item" href="#conference">Conference</a>
+</nav>
+
+<h2 id="journal">Journal</h2>
 
 <details class="cna-year" open markdown="0">
   <summary><h3>2026</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
@@ -532,7 +538,7 @@ header:
   </div>
 </details>
 
-## Conference
+<h2 id="conference">Conference</h2>
 
 <details class="cna-year" open markdown="0">
   <summary><h3>2026</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>

--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -7,7 +7,7 @@ permalink: /Publications/
 excerpt: 'Stay hungry, Stay foolish.'
 header:
   overlay_image: /assets/images/PH.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 <div class="cna-tally" markdown="0">

--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -10,29 +10,6 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-<div class="cna-tally" markdown="0">
-  <span class="cna-tally-label">Top conferences</span>
-  <span class="cna-tally-pill cna-tally-talk">CCS × 2</span>
-  <span class="cna-tally-pill cna-tally-talk">S&amp;P × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">NDSS × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">CVPR × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">ICCV × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">ECCV × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">NeurIPS × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">CRYPTO × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">EUROCRYPT × 1</span>
-  <span class="cna-tally-pill cna-tally-talk">ASIACRYPT × 2</span>
-</div>
-
-<div class="cna-tally" markdown="0">
-  <span class="cna-tally-label">Top journals</span>
-  <span class="cna-tally-pill cna-tally-paper">J. Cryptology × 1</span>
-  <span class="cna-tally-pill cna-tally-paper">IEEE TIFS × 2</span>
-  <span class="cna-tally-pill cna-tally-paper">IEEE TDSC × 2</span>
-  <span class="cna-tally-pill cna-tally-paper">Pattern Recognition × 1</span>
-  <span class="cna-tally-pill cna-tally-paper">IEEE TBIOM × 1</span>
-</div>
-
 ## Journal
 
 <details class="cna-year" open markdown="0">

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -13,17 +13,6 @@ header:
 
 # Honors & Awards
 
-<div class="cna-tally" markdown="0">
-  <span class="cna-tally-label">By tier</span>
-  <span class="cna-tally-pill cna-tally-award">Top × 3</span>
-  <span class="cna-tally-pill cna-tally-award">Excellence × 6</span>
-  <span class="cna-tally-pill cna-tally-award">Special × 5</span>
-  <span class="cna-tally-pill cna-tally-award">Excellent Paper × 1</span>
-  <span class="cna-tally-pill cna-tally-award">Outstanding × 1</span>
-  <span class="cna-tally-pill cna-tally-award">Encouragement × 2</span>
-  <span class="cna-tally-pill cna-tally-award">Participant × 3</span>
-</div>
-
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026</h3>

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -8,7 +8,7 @@ sidebar:
 permalink: /News/honor_award/
 header:
   overlay_image: /assets/images/korea.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 # Honors & Awards

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -10,128 +10,357 @@ header:
   overlay_image: /assets/images/korea.jpg
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
+
 # Honors & Awards
 
-## 2026
-<ul type="square">
-  <li>Outstanding Paper of the Week, Hanyang University.</li>
-    <ul type="-">
-  <li><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, <b>Jae Hong Seo</b></li>
-    </ul>
-</ul>
+<div class="cna-tally" markdown="0">
+  <span class="cna-tally-label">By tier</span>
+  <span class="cna-tally-pill cna-tally-award">Top × 3</span>
+  <span class="cna-tally-pill cna-tally-award">Excellence × 6</span>
+  <span class="cna-tally-pill cna-tally-award">Special × 5</span>
+  <span class="cna-tally-pill cna-tally-award">Excellent Paper × 1</span>
+  <span class="cna-tally-pill cna-tally-award">Outstanding × 1</span>
+  <span class="cna-tally-pill cna-tally-award">Encouragement × 2</span>
+  <span class="cna-tally-pill cna-tally-award">Participant × 3</span>
+</div>
 
-## 2025
-<ul type="square">
-  <li>Excellence Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-    <ul type="-">
-      <li><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung</li>
-    </ul>  
-  <li>Special Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-    <ul type="-">
-      <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b></li>
-    </ul>
-  <li>Special Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-    <ul type="-">
-      <li><b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></li>
-    </ul>
-</ul>
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2026</h3>
+    <span class="cna-year-count">1 award</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-## 2024
-<ul type="square">
-  <li>Excellence Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-    <ul type="-">
-      <li><b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim</li>
-    </ul>  
-  <li>Encouragement Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-    <ul type="-">
-      <li><b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></li>
-    </ul>
-  <li>Encouragement Award, Crypto Analysis Contest, 777th Intelligence Command, Korea.</li>
-    <ul type="-">
-        <li><b>Yunki Kim</b>, and <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</li> 
-    </ul>
-  <li> Excellent Paper Award, CISC-S'24, National Security Research Institute, Korea.</li>
-  <ul type="-">
-    <li><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b> and <b>Jae Hong Seo</b></li>
-  </ul>  
-</ul>
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Outstanding Paper of the Week</div>
+      <div class="cna-row-sub">Hanyang University · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Outstanding</span>
+    </div>
+  </article>
 
-## 2023
-<ul type="square">
-<li>Excellence Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-  <ul type="-">
-    <li><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b></li>
-  </ul>  
-<li>Participant Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></li>
-  </ul>
-<li>Special Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung</li>
-</ul>  
-<li>Top Exellence Award, Crypto Analysis Contest, 777th Intelligence Command, Korea.</li>
-<ul type="-">
-    <li><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and Shin Heo</li>
-</ul>
-<li>Top Award, Best Research Paper Award for graduate students, Research Institute for Natural Sciences, Hanyang University.</li>
-<ul type="-">
-    <li><b>Bora Jeong</b></li>
-</ul>
-</ul>
+  </div>
+</details>
 
-## 2022
-<ul type = "square">
-<li>Top Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li><b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b></li>
-</ul>   
-<li>Special Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b></li>
-</ul>   
-<li>Excellence Award, Crypto Analysis Contest, 777th Intelligence Command, Korea.</li>
-<ul type="-">
-    <li><b>Seunghun Paik</b>, <b>Minsu Kim</b>, Hyungjun Jang, Yewon Jeong, and Yeonhong Lim</li>
-</ul>     
-<li>Excellence Award, Academic Seminar, College of Natural Science, Hanyang University.</li>
-<ul type="-">
-    <li><b>Minsu Kim</b>, and <b>Seongae Baek</b></li>
-</ul>   
-<li>Participant Award, Academic Seminar, College of Natural Science, Hanyang University.</li>
-<ul type="-">
-    <li><b>Yunjeong Heo</b></li>
-</ul>   
-</ul>
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2025</h3>
+    <span class="cna-year-count">3 awards</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
 
-## 2021
-<ul type = "square">
-<li>Special Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li>Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b></li>
-</ul>    
-<li>Top Award, Academic Seminar, College of Natural Science, Hanyang University.</li>
-<ul type="-">
-    <li><b>Taesam Kim</b>, and <b>Kyuhwan Lee</b></li>
-</ul>    
-<li>Participant Award, Academic Seminar, College of Natural Science, Hanyang University.</li>
-<ul type="-">
-    <li><b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</li>
-</ul>    
-</ul>
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
 
-## 2020
-<ul type = "square">
-<li>Participant Award, National Cryptographic Technology Contest, National Intelligence Service, Korea.</li>
-<ul type="-">
-    <li><b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></li>
-</ul>  
-</ul>
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Special</span>
+    </div>
+  </article>
 
-## 2019
-<ul type = "square">
-<li>Excellence Award, Academic Seminar, College of Natural Science, Hanyang University.</li>
-<ul type="-">
-    <li><b>Sunpill Kim</b>, and <b>Seunghun Paik</b></li>
-</ul>  
-</ul>
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Special</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2024</h3>
+    <span class="cna-year-count">4 awards</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Encouragement</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Crypto Analysis Contest</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Yunki Kim</b>, <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Encouragement</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">CISC-S'24 — Excellent Paper Award</div>
+      <div class="cna-row-sub">National Security Research Institute, Korea · <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellent Paper</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2023</h3>
+    <span class="cna-year-count">5 awards</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Participant</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Special</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Crypto Analysis Contest</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and Shin Heo</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Top Excellence</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Best Research Paper Award for Graduate Students</div>
+      <div class="cna-row-sub">Research Institute for Natural Sciences, Hanyang University · <b>Bora Jeong</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Top</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022</h3>
+    <span class="cna-year-count">5 awards</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Top</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Special</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Crypto Analysis Contest</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, Hyungjun Jang, Yewon Jeong, and Yeonhong Lim</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Academic Seminar</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Minsu Kim</b>, and <b>Seongae Baek</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Academic Seminar</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Yunjeong Heo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Participant</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2021</h3>
+    <span class="cna-year-count">3 awards</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Special</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Academic Seminar</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Taesam Kim</b>, and <b>Kyuhwan Lee</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Top</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Academic Seminar</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Participant</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2020</h3>
+    <span class="cna-year-count">1 award</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">National Cryptographic Technology Contest</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Participant</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2019</h3>
+    <span class="cna-year-count">1 award</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title">Academic Seminar</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Sunpill Kim</b>, and <b>Seunghun Paik</b></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-award">Excellence</span>
+    </div>
+  </article>
+
+  </div>
+</details>

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -13,13 +13,9 @@ header:
 
 <div class="cna-tally" markdown="0">
   <span class="cna-tally-label">Summary</span>
-  <span class="cna-tally-pill cna-tally-award">Top × 3</span>
-  <span class="cna-tally-pill cna-tally-award">Excellence × 6</span>
-  <span class="cna-tally-pill cna-tally-award">Special × 5</span>
-  <span class="cna-tally-pill cna-tally-award">Excellent Paper × 1</span>
-  <span class="cna-tally-pill cna-tally-award">Outstanding × 1</span>
-  <span class="cna-tally-pill">Encouragement × 2</span>
-  <span class="cna-tally-pill">Participant × 3</span>
+  <span class="cna-tally-pill cna-tally-award">23 awards</span>
+  <span class="cna-tally-pill">2019 – 2026</span>
+  <span class="cna-tally-pill">4 institutions</span>
 </div>
 
 <details class="cna-year" open markdown="0">
@@ -120,7 +116,7 @@ header:
       <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Encouragement</span>
+      <span class="cna-chip cna-chip-award">Encouragement</span>
     </div>
   </article>
 
@@ -132,7 +128,7 @@ header:
       <div class="cna-row-recipients"><b>Yunki Kim</b>, <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Encouragement</span>
+      <span class="cna-chip cna-chip-award">Encouragement</span>
     </div>
   </article>
 
@@ -179,7 +175,7 @@ header:
       <div class="cna-row-recipients"><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Participant</span>
+      <span class="cna-chip cna-chip-award">Participant</span>
     </div>
   </article>
 
@@ -286,7 +282,7 @@ header:
       <div class="cna-row-recipients"><b>Yunjeong Heo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Participant</span>
+      <span class="cna-chip cna-chip-award">Participant</span>
     </div>
   </article>
 
@@ -333,7 +329,7 @@ header:
       <div class="cna-row-recipients"><b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Participant</span>
+      <span class="cna-chip cna-chip-award">Participant</span>
     </div>
   </article>
 
@@ -356,7 +352,7 @@ header:
       <div class="cna-row-recipients"><b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-muted">Participant</span>
+      <span class="cna-chip cna-chip-award">Participant</span>
     </div>
   </article>
 

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -11,13 +11,6 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-<div class="cna-tally" markdown="0">
-  <span class="cna-tally-label">Summary</span>
-  <span class="cna-tally-pill cna-tally-award">23 awards</span>
-  <span class="cna-tally-pill">2019 – 2026</span>
-  <span class="cna-tally-pill">4 institutions</span>
-</div>
-
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026</h3>

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -11,8 +11,6 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-# Honors & Awards
-
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026</h3>
@@ -21,8 +19,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Outstanding Paper of the Week</div>
       <div class="cna-row-sub">Hanyang University · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, <b>Jae Hong Seo</b></div>
@@ -43,8 +41,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
@@ -54,8 +52,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b></div>
@@ -65,8 +63,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
@@ -87,8 +85,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim</div>
@@ -98,30 +96,30 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Encouragement</span>
+      <span class="cna-chip cna-chip-muted">Encouragement</span>
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
       <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Yunki Kim</b>, <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Encouragement</span>
+      <span class="cna-chip cna-chip-muted">Encouragement</span>
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">CISC-S'24 — Excellent Paper Award</div>
       <div class="cna-row-sub">National Security Research Institute, Korea · <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
@@ -142,8 +140,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b></div>
@@ -153,19 +151,19 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Participant</span>
+      <span class="cna-chip cna-chip-muted">Participant</span>
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung</div>
@@ -175,8 +173,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
       <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and Shin Heo</div>
@@ -186,8 +184,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Best Research Paper Award for Graduate Students</div>
       <div class="cna-row-sub">Research Institute for Natural Sciences, Hanyang University · <b>Bora Jeong</b></div>
@@ -208,8 +206,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b></div>
@@ -219,8 +217,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b></div>
@@ -230,8 +228,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
       <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, Hyungjun Jang, Yewon Jeong, and Yeonhong Lim</div>
@@ -241,8 +239,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
       <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Minsu Kim</b>, and <b>Seongae Baek</b></div>
@@ -252,14 +250,14 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
       <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Yunjeong Heo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Participant</span>
+      <span class="cna-chip cna-chip-muted">Participant</span>
     </div>
   </article>
 
@@ -274,8 +272,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b></div>
@@ -285,8 +283,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
       <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Taesam Kim</b>, and <b>Kyuhwan Lee</b></div>
@@ -296,14 +294,14 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
       <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Participant</span>
+      <span class="cna-chip cna-chip-muted">Participant</span>
     </div>
   </article>
 
@@ -318,14 +316,14 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
       <div class="cna-row-sub">National Intelligence Service, Korea · <b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
-      <span class="cna-chip cna-chip-award">Participant</span>
+      <span class="cna-chip cna-chip-muted">Participant</span>
     </div>
   </article>
 
@@ -340,8 +338,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
       <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Sunpill Kim</b>, and <b>Seunghun Paik</b></div>

--- a/_pages/honer_award.md
+++ b/_pages/honer_award.md
@@ -11,6 +11,17 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
+<div class="cna-tally" markdown="0">
+  <span class="cna-tally-label">Summary</span>
+  <span class="cna-tally-pill cna-tally-award">Top × 3</span>
+  <span class="cna-tally-pill cna-tally-award">Excellence × 6</span>
+  <span class="cna-tally-pill cna-tally-award">Special × 5</span>
+  <span class="cna-tally-pill cna-tally-award">Excellent Paper × 1</span>
+  <span class="cna-tally-pill cna-tally-award">Outstanding × 1</span>
+  <span class="cna-tally-pill">Encouragement × 2</span>
+  <span class="cna-tally-pill">Participant × 3</span>
+</div>
+
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026</h3>
@@ -23,7 +34,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Outstanding Paper of the Week</div>
-      <div class="cna-row-sub">Hanyang University · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">Hanyang University</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Outstanding</span>
@@ -45,7 +57,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, Nirajan Koirala, Jack Nero, <b>Hyunjung Son</b>, <b>Yunki Kim</b>, <b>Jae Hong Seo</b>, and Taeho Jung</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>
@@ -56,7 +69,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Special</span>
@@ -67,7 +81,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, Yong Kiam Tan, Tianchi Liu, <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Special</span>
@@ -89,7 +104,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Hyeonbum Lee</b>, Jaehwan Park, Junbeom Hur, <b>Jae Hong Seo</b>, and Doowon Kim</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>
@@ -100,7 +116,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Minsu Kim</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Encouragement</span>
@@ -111,7 +128,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
-      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Yunki Kim</b>, <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea</div>
+      <div class="cna-row-recipients"><b>Yunki Kim</b>, <b>Minsu Kim</b>, Wanki Kim, Seonjae Kim</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Encouragement</span>
@@ -122,7 +140,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">CISC-S'24 — Excellent Paper Award</div>
-      <div class="cna-row-sub">National Security Research Institute, Korea · <b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Security Research Institute, Korea</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Dongsoo Kim</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellent Paper</span>
@@ -144,7 +163,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Sunpill Kim</b>, <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, Junbum Shin, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>
@@ -155,7 +175,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Sunpill Kim</b>, Yong Kiam Tan, <b>Bora Jeong</b>, Soumik Mondal, Khin Mi Mi Aung, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Participant</span>
@@ -166,7 +187,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung</div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Hyeonbum Lee</b>, <b>Kyuhwan Lee</b>, <b>Jae Hong Seo</b>, Wenyi Tang, Shankha Shubhra Mukherjee, and Taeho Jung</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Special</span>
@@ -177,7 +199,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
-      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and Shin Heo</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Minsu Kim</b>, and Shin Heo</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Top Excellence</span>
@@ -188,7 +211,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Best Research Paper Award for Graduate Students</div>
-      <div class="cna-row-sub">Research Institute for Natural Sciences, Hanyang University · <b>Bora Jeong</b></div>
+      <div class="cna-row-sub">Research Institute for Natural Sciences, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Bora Jeong</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Top</span>
@@ -210,7 +234,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Hyeonbum Lee</b>, Sungwook Kim, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Top</span>
@@ -221,7 +246,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Sunpill Kim</b>, Hoyong Shin, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Special</span>
@@ -232,7 +258,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Crypto Analysis Contest</div>
-      <div class="cna-row-sub">777th Intelligence Command, Korea · <b>Seunghun Paik</b>, <b>Minsu Kim</b>, Hyungjun Jang, Yewon Jeong, and Yeonhong Lim</div>
+      <div class="cna-row-sub">777th Intelligence Command, Korea</div>
+      <div class="cna-row-recipients"><b>Seunghun Paik</b>, <b>Minsu Kim</b>, Hyungjun Jang, Yewon Jeong, and Yeonhong Lim</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>
@@ -243,7 +270,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
-      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Minsu Kim</b>, and <b>Seongae Baek</b></div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Minsu Kim</b>, and <b>Seongae Baek</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>
@@ -254,7 +282,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
-      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Yunjeong Heo</b></div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Yunjeong Heo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Participant</span>
@@ -276,7 +305,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients">Sungwook Kim, <b>Hyeonbum Lee</b>, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Special</span>
@@ -287,7 +317,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
-      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Taesam Kim</b>, and <b>Kyuhwan Lee</b></div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Taesam Kim</b>, and <b>Kyuhwan Lee</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Top</span>
@@ -298,7 +329,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
-      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Chanwoo Hwang</b>, <b>Dongsu Kim</b>, and Hwanseong Kim</div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Participant</span>
@@ -320,7 +352,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">National Cryptographic Technology Contest</div>
-      <div class="cna-row-sub">National Intelligence Service, Korea · <b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></div>
+      <div class="cna-row-sub">National Intelligence Service, Korea</div>
+      <div class="cna-row-recipients"><b>Heewon Chung</b>, Kyoohyung Han, <b>Chanyang Ju</b>, Myungsun Kim, and <b>Jae Hong Seo</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-muted">Participant</span>
@@ -342,7 +375,8 @@ header:
 
     <div class="cna-row-main">
       <div class="cna-row-title">Academic Seminar</div>
-      <div class="cna-row-sub">College of Natural Science, Hanyang University · <b>Sunpill Kim</b>, and <b>Seunghun Paik</b></div>
+      <div class="cna-row-sub">College of Natural Science, Hanyang University</div>
+      <div class="cna-row-recipients"><b>Sunpill Kim</b>, and <b>Seunghun Paik</b></div>
     </div>
     <div class="cna-row-aside">
       <span class="cna-chip cna-chip-award">Excellence</span>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -11,8 +11,6 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-# C&A in Media
-
 ## Newspaper Article
 
 <details class="cna-year" open markdown="0">
@@ -23,8 +21,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://edu.donga.com/news/articleView.html?idxno=99515">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
       <div class="cna-row-sub">김재성</div>
@@ -35,8 +33,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.m-i.kr/news/articleView.html?idxno=1310090">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
       <div class="cna-row-sub">장원석</div>
@@ -47,8 +45,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://news.unn.net/news/articleView.html?idxno=586959">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
       <div class="cna-row-sub">박인규</div>
@@ -59,8 +57,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.newstnt.com/news/articleView.html?idxno=561321">한양대 서재홍 연구팀, 상용 얼굴인식 시스템을 속이는 ‘1회성 비적응 공격’ 기법으로 NeurIPS 2025 채택.</a></div>
       <div class="cna-row-sub">성영희</div>
@@ -71,8 +69,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.kyosu.net/news/articleView.html?idxno=150951">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명… NeurIPS 2025서 발표.</a></div>
       <div class="cna-row-sub">하영</div>
@@ -83,8 +81,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.veritas-a.com/news/articleView.html?idxno=586613">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 '1회성 공격' 가능성 최초 규명… NeurIPS 2025서 발표.</a></div>
       <div class="cna-row-sub">김하연</div>
@@ -95,8 +93,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.veritas-a.com/news/articleView.html?idxno=546987">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">김하연</div>
@@ -107,8 +105,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.newstnt.com/news/articleView.html?idxno=471831">한양대 수학과 서재홍 교수 연구팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">성영희</div>
@@ -119,8 +117,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.joongangenews.com/news/articleView.html?idxno=414275">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">김선정</div>
@@ -131,8 +129,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.asiatime.co.kr/article/20250325500390">[25일 대학가] 중앙대·한양대·성신여대.</a></div>
       <div class="cna-row-sub">양혜랑</div>
@@ -143,8 +141,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.kyosu.net/news/articleView.html?idxno=132454">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">배지우</div>
@@ -155,8 +153,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.kfenews.co.kr/news/articleView.html?idxno=632418">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">정혜인</div>
@@ -167,8 +165,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.m-i.kr/news/articleView.html?idxno=1220990">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
       <div class="cna-row-sub">김다니엘</div>
@@ -179,8 +177,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://news.nate.com/view/20250325n08007">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
     </div>
@@ -190,8 +188,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.fnnews.com/news/202503250927374259">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
     </div>
@@ -201,8 +199,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.enewstoday.co.kr/news/articleView.html?idxno=2254419">한양대 서재홍 교수팀, 얼굴 인증 API 공격 기법 발표.</a></div>
       <div class="cna-row-sub">권오경</div>
@@ -213,8 +211,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.newsis.com/view/NISX20250325_0003111474">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
       <div class="cna-row-sub">윤신영</div>
@@ -225,8 +223,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.hani.co.kr/arti/economy/biznews/1188694.html">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
     </div>
@@ -247,8 +245,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.newshyu.com/news/articleView.html?idxno=1007599">이현범 학생, 국가암호공모전 대상 수상과 함께 세계적 암호 학회에서 인정 받아.</a></div>
       <div class="cna-row-sub">한수연</div>
@@ -259,8 +257,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="http://www.newshyu.com/news/articleView.html?idxno=1007644">한양대 학생팀, 한국암호포럼 주관 ‘2022 국가암호공모전’에서 대상 수상.</a></div>
       <div class="cna-row-sub">이해울</div>
@@ -282,8 +280,8 @@ header:
   </summary>
   <div class="cna-year-body">
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="http://www.newshyu.com/news/articleView.html?idxno=414743">서재홍 교수 ‘올해의 신진 연구자’ 선정.</a></div>
       <div class="cna-row-sub">디지털뉴스팀</div>
@@ -294,8 +292,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="http://www.popsci.co.kr/news/articleView.html?idxno=8202">한국연구재단, ‘올해의 신진연구자’ 10인 선정 시상식 개최.</a></div>
       <div class="cna-row-sub">이고운</div>
@@ -306,8 +304,8 @@ header:
     </div>
   </article>
 
-  <article class="cna-row">
-    <span class="cna-row-meta"></span>
+  <article class="cna-row cna-row--no-meta">
+
     <div class="cna-row-main">
       <div class="cna-row-title"><a href="https://www.hellodd.com/news/articleView.html?idxno=66660">세계서 인정한 한국 ‘젊은 연구자’ 10인.</a></div>
       <div class="cna-row-sub">길애경</div>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -335,9 +335,9 @@ header:
     </div>
   </article>
 
-  <article class="cna-card cna-cat-talk">
+  <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-talk">Interview</span>
+      <span class="cna-chip cna-chip-seminar">Interview</span>
       <time class="cna-card-meta">YouTube</time>
     </header>
     <div class="cna-card-body">
@@ -347,9 +347,9 @@ header:
     </div>
   </article>
 
-  <article class="cna-card cna-cat-talk">
+  <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-talk">Lab Intro</span>
+      <span class="cna-chip cna-chip-seminar">Lab Intro</span>
       <time class="cna-card-meta">YouTube</time>
     </header>
     <div class="cna-card-body">
@@ -371,9 +371,9 @@ header:
     </div>
   </article>
 
-  <article class="cna-card cna-cat-talk">
+  <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-talk">Lecture</span>
+      <span class="cna-chip cna-chip-seminar">Lecture</span>
       <time class="cna-card-meta">2022</time>
     </header>
     <div class="cna-card-body">

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -8,7 +8,7 @@ sidebar:
 permalink: /News/media/
 header:
   overlay_image: /assets/images/korea.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 # C&A in Media

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -10,125 +10,378 @@ header:
   overlay_image: /assets/images/korea.jpg
   overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
 ---
+
 # C&A in Media
-## Newspaper Article 
-<ul type="disc">
-      <li>
-        <A href="https://edu.donga.com/news/articleView.html?idxno=99515">
-            김재성, 한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.
-        </A>
-        E동아. 2025년 12월 2일
-        https://edu.donga.com/news/articleView.html?idxno=99515
-    </li>
-    <li>
-        <A href="https://www.m-i.kr/news/articleView.html?idxno=1310090">
-            장원석, 한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.
-        </A>
-        매일일보. 2025년 12월 2일
-        https://www.m-i.kr/news/articleView.html?idxno=1310090
-    </li>
-    <li>
-        <A href="https://news.unn.net/news/articleView.html?idxno=586959">
-            박인규, 한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.
-        </A>
-        한국대학신문. 2025년 12월 2일
-        https://news.unn.net/news/articleView.html?idxno=586959
-    </li>
-    <li>
-        <A href="https://www.newstnt.com/news/articleView.html?idxno=561321">
-            성영희, 한양대 서재홍 연구팀, 상용 얼굴인식 시스템을 속이는 ‘1회성 비적응 공격’ 기법으로 NeurIPS 2025 채택.
-        </A>
-        뉴스티앤티. 2025년 12월 2일
-        https://www.newstnt.com/news/articleView.html?idxno=561321
-    </li>
-    <li>
-        <A href="https://www.kyosu.net/news/articleView.html?idxno=150951">
-            하영, 한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명... NeurIPS 2025서 발표.
-        </A>
-        교수신문. 2025년 12월 2일
-        https://www.kyosu.net/news/articleView.html?idxno=150951
-    </li>
-    <li>
-        <A href="https://www.veritas-a.com/news/articleView.html?idxno=586613">
-            김하연, 한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 '1회성 공격' 가능성 최초 규명... NeurIPS 2025서 발표.
-        </A>
-        베리타스알파. 2025년 12월 2일
-        https://www.veritas-a.com/news/articleView.html?idxno=586613
-    </li>
-    <li>
-        <A href= "https://www.veritas-a.com/news/articleView.html?idxno=546987">"김하연, 한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증".</A>베리타스알파. 2025년 3월 25일 https://www.veritas-a.com/news/articleView.html?idxno=546987
-    </li> 
-    <li>
-        <A href= "https://www.newstnt.com/news/articleView.html?idxno=471831">"성영희, 한양대 수학과 서재홍 교수 연구팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증".</A>뉴스티앤티. 2025년 3월 25일 https://www.newstnt.com/news/articleView.html?idxno=471831
-    </li> 
-    <li>
-        <A href= "https://www.joongangenews.com/news/articleView.html?idxno=414275">"김선정, 한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증".</A>중앙이코노미뉴스. 2025년 3월 25일 https://www.joongangenews.com/news/articleView.html?idxno=414275
-    </li> 
-    <li>
-        <A href= "https://www.asiatime.co.kr/article/20250325500390#_enliple#_mobwcvr">"양혜랑, [25일 대학가] 중앙대·한양대·성신여대".</A>아시아타임즈. 2025년 3월 25일 https://www.asiatime.co.kr/article/20250325500390#_enliple#_mobwcvr
-    </li> 
-    <li>
-        <A href= "https://www.kyosu.net/news/articleView.html?idxno=132454">"배지우, 한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증".</A>교수신문. 2025년 3월 25일 https://www.kyosu.net/news/articleView.html?idxno=132454
-    </li> 
-    <li>
-        <A href= "https://www.kfenews.co.kr/news/articleView.html?idxno=632418">"정혜인, 한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템 보안 취약점 입증".</A>한국금융경제신문. 2025년 3월 25일 https://www.kfenews.co.kr/news/articleView.html?idxno=632418
-    </li> 
-    <li>
-        <A href= "https://www.m-i.kr/news/articleView.html?idxno=1220990">"김다니엘, 한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증".</A>매일일보. 2025년 3월 25일 https://www.m-i.kr/news/articleView.html?idxno=1220990
-    </li> 
-    <li>
-        <A href= "https://news.nate.com/view/20250325n08007">"한양대, 얼굴 인증 시스템 취약성 실험으로 증명".</A>네이트뉴스. 2025년 3월 25일 https://news.nate.com/view/20250325n08007
-    </li> 
-    <li>
-        <A href= "https://www.fnnews.com/news/202503250927374259">"한양대, 얼굴 인증 시스템 취약성 실험으로 증명".</A>파이낸셜뉴스. 2025년 3월 25일 https://www.fnnews.com/news/202503250927374259
-    </li> 
-    <li>
-        <A href= "https://www.enewstoday.co.kr/news/articleView.html?idxno=2254419">"권오경, 한양대 서재홍 교수팀, 얼굴 인증 API 공격 기법 발표".</A>이뉴스투데이. 2025년 3월 25일 https://www.enewstoday.co.kr/news/articleView.html?idxno=2254419
-    </li> 
-    <li>
-        <A href= "https://www.newsis.com/view/NISX20250325_0003111474">"윤신영, 한양대, 얼굴 인증 시스템 취약성 실험으로 증명".</A>뉴시스. 2025년 3월 25일 https://www.newsis.com/view/NISX20250325_0003111474
-    </li> 
-    <li>
-        <A href= "https://www.hani.co.kr/arti/economy/biznews/1188694.html">"한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안
-취약점 입증".</A>한겨레. 2025년 3월 25일 https://www.hani.co.kr/arti/economy/biznews/1188694.html
-    </li> 
-    <li>
-        <A href= "https://www.newshyu.com/news/articleView.html?idxno=1007599">한수연, "이현범 학생, 국가암호공모전 대상 수상과 함께 세계적 암호 학회에서 인정 받아".</A> NewsH. 2022년 10월 20일 https://www.newshyu.com/news/articleView.html?idxno=1007599
-    </li>  
-    <li>
-         <A href= "http://www.newshyu.com/news/articleView.html?idxno=1007644">이해울, "한양대 학생팀, 한국암호포럼 주관 '2022 국가암호공모전'에서 대상 수상".</A> NewsH. 2022년 10월 24일 http://www.newshyu.com/news/articleView.html?idxno=1007644
-    </li> 
-    <li>
-         <A href= "http://www.newshyu.com/news/articleView.html?idxno=414743">디지털뉴스팀, "서재홍 교수 '올해의 신진 연구자' 선정".</A> NewsH. 2018년 11월 19일 http://www.newshyu.com/news/articleView.html?idxno=414743
-    </li> 
-    <li>
-         <A href= "http://www.popsci.co.kr/news/articleView.html?idxno=8202 ">이고운, "한국연구재단, '올해의 신진연구자' 10인 선정 시상식 개최".</A> POPULARSCIENCE. 2018년 11월 12일 http://www.popsci.co.kr/news/articleView.html?idxno=8202 
-    </li>
-    <li>
-         <A href= "https://www.hellodd.com/news/articleView.html?idxno=66660">길애경, "세계서 인정한 한국 '젊은 연구자' 10인".</A> 헬로디디. 2018년 11월 13일 https://www.hellodd.com/news/articleView.html?idxno=66660
-    </li>  
-</ul>
+
+## Newspaper Article
+
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2025</h3>
+    <span class="cna-year-count">18 articles</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://edu.donga.com/news/articleView.html?idxno=99515">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
+      <div class="cna-row-sub">김재성</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">E동아 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.m-i.kr/news/articleView.html?idxno=1310090">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
+      <div class="cna-row-sub">장원석</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">매일일보 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://news.unn.net/news/articleView.html?idxno=586959">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명.</a></div>
+      <div class="cna-row-sub">박인규</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">한국대학신문 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.newstnt.com/news/articleView.html?idxno=561321">한양대 서재홍 연구팀, 상용 얼굴인식 시스템을 속이는 ‘1회성 비적응 공격’ 기법으로 NeurIPS 2025 채택.</a></div>
+      <div class="cna-row-sub">성영희</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">뉴스티앤티 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.kyosu.net/news/articleView.html?idxno=150951">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 ‘1회성 공격’ 가능성 최초 규명… NeurIPS 2025서 발표.</a></div>
+      <div class="cna-row-sub">하영</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">교수신문 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.veritas-a.com/news/articleView.html?idxno=586613">한양대 서재홍 교수팀, 상용 얼굴 인식 시스템 '1회성 공격' 가능성 최초 규명… NeurIPS 2025서 발표.</a></div>
+      <div class="cna-row-sub">김하연</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">베리타스알파 · 2025.12.02</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.veritas-a.com/news/articleView.html?idxno=546987">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">김하연</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">베리타스알파 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.newstnt.com/news/articleView.html?idxno=471831">한양대 수학과 서재홍 교수 연구팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">성영희</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">뉴스티앤티 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.joongangenews.com/news/articleView.html?idxno=414275">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">김선정</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">중앙이코노미뉴스 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.asiatime.co.kr/article/20250325500390">[25일 대학가] 중앙대·한양대·성신여대.</a></div>
+      <div class="cna-row-sub">양혜랑</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">아시아타임즈 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.kyosu.net/news/articleView.html?idxno=132454">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">배지우</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">교수신문 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.kfenews.co.kr/news/articleView.html?idxno=632418">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">정혜인</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">한국금융경제신문 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.m-i.kr/news/articleView.html?idxno=1220990">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+      <div class="cna-row-sub">김다니엘</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">매일일보 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://news.nate.com/view/20250325n08007">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">네이트뉴스 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.fnnews.com/news/202503250927374259">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">파이낸셜뉴스 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.enewstoday.co.kr/news/articleView.html?idxno=2254419">한양대 서재홍 교수팀, 얼굴 인증 API 공격 기법 발표.</a></div>
+      <div class="cna-row-sub">권오경</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">이뉴스투데이 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.newsis.com/view/NISX20250325_0003111474">한양대, 얼굴 인증 시스템 취약성 실험으로 증명.</a></div>
+      <div class="cna-row-sub">윤신영</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">뉴시스 · 2025.03.25</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.hani.co.kr/arti/economy/biznews/1188694.html">한양대 서재홍 교수팀, 딥러닝 기반 얼굴 인증 시스템의 보안 취약점 입증.</a></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">한겨레 · 2025.03.25</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2022</h3>
+    <span class="cna-year-count">2 articles</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.newshyu.com/news/articleView.html?idxno=1007599">이현범 학생, 국가암호공모전 대상 수상과 함께 세계적 암호 학회에서 인정 받아.</a></div>
+      <div class="cna-row-sub">한수연</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">NewsH · 2022.10.20</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="http://www.newshyu.com/news/articleView.html?idxno=1007644">한양대 학생팀, 한국암호포럼 주관 ‘2022 국가암호공모전’에서 대상 수상.</a></div>
+      <div class="cna-row-sub">이해울</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">NewsH · 2022.10.24</span>
+    </div>
+  </article>
+
+  </div>
+</details>
+
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2018</h3>
+    <span class="cna-year-count">3 articles</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="http://www.newshyu.com/news/articleView.html?idxno=414743">서재홍 교수 ‘올해의 신진 연구자’ 선정.</a></div>
+      <div class="cna-row-sub">디지털뉴스팀</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">NewsH · 2018.11.19</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="http://www.popsci.co.kr/news/articleView.html?idxno=8202">한국연구재단, ‘올해의 신진연구자’ 10인 선정 시상식 개최.</a></div>
+      <div class="cna-row-sub">이고운</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">POPULARSCIENCE · 2018.11.12</span>
+    </div>
+  </article>
+
+  <article class="cna-row">
+    <span class="cna-row-meta"></span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><a href="https://www.hellodd.com/news/articleView.html?idxno=66660">세계서 인정한 한국 ‘젊은 연구자’ 10인.</a></div>
+      <div class="cna-row-sub">길애경</div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-people">Press</span>
+      <span class="cna-row-aside-detail">헬로디디 · 2018.11.13</span>
+    </div>
+  </article>
+
+  </div>
+</details>
 
 ## Video
-<ul type="disc">
-    <li>
-        Security Analysis on Locality-Sensitive Hashing-based Biometric Template Protection Schemes (Presenter : Seunghun Paik)
-    </li>
-    <iframe width="560" height="315" src="https://bmvc2022.mpi-inf.mpg.de/BMVC2023/0535_video.mp4"></iframe>
-    <li>
-        교수님, 수학이 뭐라고 생각하세요? | 서재홍 교수님 인터뷰 | 한양대 수학과 
-    </li>
-    {% include video id="LT16gmAula4" provider="youtube" %}  
-    <li>
-       [연구탐탐] 서재홍 교수님 Cryptology & Algorithm Lab ｜한양대수학과
-    </li>
-    {% include video id="V6_3YWusRH4" provider="youtube" %}  
-    <li>
-        Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier (Presenter : Hyeonbum Lee)
-    </li>
-    {% include video id="60au1ngMrVc" provider="youtube" %}  
-    <li>
-        2022 KpqC Summer School 영지식 증명과 암호 Part I
-    </li>
-    {% include video id="jDk5KAW-VnQ" provider="youtube" %}  
-</ul>
+
+<div class="cna-card-grid" markdown="0">
+
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Conference Talk</span>
+      <time class="cna-card-meta">BMVC 2023</time>
+    </header>
+    <div class="cna-card-body">
+      <p><b>Security Analysis on Locality-Sensitive Hashing-based Biometric Template Protection Schemes</b><br>
+      <span style="color:var(--cna-soft)">Presenter: Seunghun Paik</span></p>
+      <iframe width="560" height="315" src="https://bmvc2022.mpi-inf.mpg.de/BMVC2023/0535_video.mp4" style="max-width:100%; border-radius:var(--cna-radius-md);"></iframe>
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Interview</span>
+      <time class="cna-card-meta">YouTube</time>
+    </header>
+    <div class="cna-card-body">
+      <p><b>교수님, 수학이 뭐라고 생각하세요? — 서재홍 교수님 인터뷰</b><br>
+      <span style="color:var(--cna-soft)">한양대 수학과</span></p>
+      {% include video id="LT16gmAula4" provider="youtube" %}
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Lab Intro</span>
+      <time class="cna-card-meta">YouTube</time>
+    </header>
+    <div class="cna-card-body">
+      <p><b>[연구탐탐] 서재홍 교수님 Cryptology &amp; Algorithm Lab</b><br>
+      <span style="color:var(--cna-soft)">한양대수학과</span></p>
+      {% include video id="V6_3YWusRH4" provider="youtube" %}
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Conference Talk</span>
+      <time class="cna-card-meta">ASIACRYPT 2022</time>
+    </header>
+    <div class="cna-card-body">
+      <p><b>Efficient Zero-Knowledge Arguments in Discrete Logarithm Setting: Sublogarithmic Proof or Sublinear Verifier</b><br>
+      <span style="color:var(--cna-soft)">Presenter: Hyeonbum Lee</span></p>
+      {% include video id="60au1ngMrVc" provider="youtube" %}
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Lecture</span>
+      <time class="cna-card-meta">2022</time>
+    </header>
+    <div class="cna-card-body">
+      <p><b>2022 KpqC Summer School — 영지식 증명과 암호 Part I</b></p>
+      {% include video id="jDk5KAW-VnQ" provider="youtube" %}
+    </div>
+  </article>
+
+</div>

--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <time class="cna-card-meta">Apr 13, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.</p>
+      <p>Accepted for publication at <b>IEEE Access</b>.</p>
       <p><b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b><br>
       <i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i></p>
     </div>
@@ -73,7 +73,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <time class="cna-card-meta">Apr 10, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Accepted for publication at <b style="color:var(--cna-indigo)">ACM CCS 2026</b>.</p>
+      <p>Accepted for publication at <b>ACM CCS 2026</b>.</p>
       <p><b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b><br>
       <i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i></p>
     </div>
@@ -95,10 +95,10 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <time class="cna-card-meta">Apr 3, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Selected <b style="color:var(--cna-forest)">Outstanding Paper</b> at Hanyang University.</p>
+      <p>Selected <b>Outstanding Paper</b> at Hanyang University.</p>
       <p><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim,</b> and <b>Jae Hong Seo*</b><br>
       <i>On the Reversibility of Locality-Sensitive Hashing-Based Biometric Template Protections</i><br>
-      <b style="color:var(--cna-crimson)">IEEE Transactions on Dependable and Secure Computing</b></p>
+      <b>IEEE Transactions on Dependable and Secure Computing</b></p>
     </div>
   </article>
 
@@ -122,7 +122,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <time class="cna-card-meta">Feb 5, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Sunpill Kim will receive the <b style="color:var(--cna-forest)">Outstanding Ph.D. Dissertation Award</b> from Hanyang University.</p>
+      <p>Sunpill Kim will receive the <b>Outstanding Ph.D. Dissertation Award</b> from Hanyang University.</p>
       <p><b>Sunpill Kim</b><br>
       <i>Score-Based Non-Adaptive Attack Against Face Recognition Systems</i></p>
     </div>
@@ -134,7 +134,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <time class="cna-card-meta">Jan 13, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.</p>
+      <p>Accepted for publication at <b>IEEE Access</b>.</p>
       <p><b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b><br>
       <i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i></p>
     </div>

--- a/index.md
+++ b/index.md
@@ -28,6 +28,19 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
   <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-seminar">Seminar</span>
+      <time class="cna-card-meta">May 29, 2026</time>
+    </header>
+    <div class="cna-card-body">
+      <p>Prof. Taeho Jung from the University of Notre Dame will visit the C&amp;A Lab for a research-topic exchange.</p>
+      <ul>
+        <li>Date &amp; Place: 01:00 PM – 04:00 PM, May 29 / Natural Science Building 702</li>
+      </ul>
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-seminar">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-seminar">Seminar</span>
       <time class="cna-card-meta">May 20, 2026</time>
     </header>
     <div class="cna-card-body">

--- a/index.md
+++ b/index.md
@@ -9,11 +9,19 @@ header:
   overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
-# About us
+<nav class="cna-page-toc" aria-label="Section navigation" markdown="0">
+  <span class="cna-page-toc-label">On this page</span>
+  <a class="cna-page-toc-item" href="#about-us">About us</a>
+  <a class="cna-page-toc-item" href="#annual-news">Annual News</a>
+  <a class="cna-page-toc-item" href="#seminar">Seminar</a>
+  <a class="cna-page-toc-item" href="#contact">Contact</a>
+</nav>
 
-We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](https://sites.google.com/site/jhsbhs/). Our main research interests are in cryptography especially zero-knowledge proof. Besides cryptography, we're interested in artificial intelligence using deep learning such as face recognition and speaker recognition.
+<h1 id="about-us">About us</h1>
 
-## Annual News
+We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo](https://sites.google.com/site/jhsbhs/). Our main research interests are in cryptography especially zero-knowledge proof. Besides cryptography, we're interested in artificial intelligence using deep learning such as face recognition and speaker recognition.
+
+<h2 id="annual-news">Annual News</h2>
 
 <div class="cna-card-grid" markdown="0">
 
@@ -153,7 +161,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 </div>
 
 <header class="cna-section-head" markdown="0" style="margin-top:var(--cna-s-8);">
-  <h2 style="margin:0;">Seminar</h2>
+  <h2 id="seminar" style="margin:0;">Seminar</h2>
   <a class="cna-section-action" href="mailto:jaehongseo@hanyang.ac.kr">Interested in joining the lab? ↗</a>
 </header>
 
@@ -551,6 +559,6 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
   </div>
 </details>
 
-## Contact
+<h2 id="contact">Contact</h2>
 
 For any inquiries, you can reach us via email: **jaehongseo@hanyang.ac.kr**

--- a/index.md
+++ b/index.md
@@ -15,82 +15,179 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
 ## Annual News
 
-<ul type="square">
-  <li>
-      (May 20, 2026) Prof. Yongha Son from Sungshin Women’s University will visit the C&A Lab and give a lecture.
-      <ul type="disc">  
-        <li>Date & Place: 01:30 PM, May 21 / Natural Science Building 102 </li>
+<style type="text/css">
+.cna-news{ display:grid; gap:14px; grid-template-columns:1fr; margin:8px 0 28px; }
+.cna-news-card{
+  background:#fff; border:1px solid #e6e2d8; border-radius:14px;
+  padding:16px 20px;
+  box-shadow:0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
+  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+.cna-news-card:hover{
+  transform:translateY(-2px);
+  box-shadow:0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
+}
+.cna-news-head{
+  display:flex; align-items:baseline; justify-content:space-between;
+  gap:12px; margin-bottom:8px; flex-wrap:wrap;
+}
+.cna-news-chip{
+  font-size:11px; font-weight:600; letter-spacing:.12em;
+  text-transform:uppercase; padding:4px 10px; border-radius:999px; white-space:nowrap;
+}
+.cna-news-date{ font-size:12.5px; color:#8a909a; white-space:nowrap; font-weight:500; }
+.cna-news-body{ font-size:15px; color:#1f2227; line-height:1.6; }
+.cna-news-body ul{ margin:6px 0 0; padding-left:1.2em; }
+.cna-news-body details summary{ cursor:pointer; color:#52575f; font-size:13.5px; }
+
+.cna-red     .cna-news-chip{ background:#fbe7eb; color:#b6102d; }
+.cna-red:hover    { border-color:#DC143C; }
+.cna-blue    .cna-news-chip{ background:#eaf1fa; color:#2b5285; }
+.cna-blue:hover   { border-color:#4169E1; }
+.cna-green   .cna-news-chip{ background:#e8f4ee; color:#176549; }
+.cna-green:hover  { border-color:#08A709; }
+.cna-amber   .cna-news-chip{ background:#fdf4e3; color:#b8740a; }
+.cna-amber:hover  { border-color:#b8740a; }
+.cna-neutral .cna-news-chip{ background:#eeece7; color:#52575f; }
+.cna-neutral:hover{ border-color:#8a909a; }
+</style>
+
+<div class="cna-news" markdown="0">
+
+  <article class="cna-news-card cna-blue">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Seminar</span>
+      <span class="cna-news-date">May 20, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Prof. Yongha Son from Sungshin Women’s University will visit the C&amp;A Lab and give a lecture.
+      <ul type="disc">
+        <li>Date &amp; Place: 01:30 PM, May 21 / Natural Science Building 102</li>
         <li>Title: Private Set Intersection</li>
       </ul>
-  </li>
-  <li>
-     (May 4, 2026) Two undergraduate students <b>Hyeonmin Jang</b> and <b>Ingeun Yun</b> joined our Cryptology & Algorithm Lab. We are delighted to welcome them.
-  </li>
-  <li>
-      (Apr 20, 2026) Dr. Keewoo Lee from the Ethereum Foundation visited the C&A Lab and gave a lecture.
-      <ul type="disc">  
-        <li>Date & Place: 01:00 PM, Apr 20 / Natural Science Building 702 </li>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-neutral">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Member</span>
+      <span class="cna-news-date">May 4, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Two undergraduate students <b>Hyeonmin Jang</b> and <b>Ingeun Yun</b> joined our Cryptology &amp; Algorithm Lab. We are delighted to welcome them.
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-blue">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Seminar</span>
+      <span class="cna-news-date">Apr 20, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Dr. Keewoo Lee from the Ethereum Foundation visited the C&amp;A Lab and gave a lecture.
+      <ul type="disc">
+        <li>Date &amp; Place: 01:00 PM, Apr 20 / Natural Science Building 702</li>
         <li>Title: Private Information Retrieval</li>
       </ul>
-  </li>
-  <li>
-      (Apr 13, 2026) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b><br><i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-      (Apr 10, 2026) The following paper has been accepted for publication at <b><span style = "color : #4169E1">ACM CCS 2026</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b><br><i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-    (Apr 9, 2026) <b>Yunki Kim</b> has been selected for the National Cryptographic Expert Training Program (NACET) 12th cohort.
-  </li>
-  <li>
-      (Apr 3, 2026) The following paper has been selected <b><span style = "color : #08A709">Outstanding Paper</span></b> at Hanyang University.
-      <ul type="disc">
-          <li>
-              <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim,</b> and <b>Jae Hong Seo*</b><br>
-              <i>On the Reversibility of Locality-Sensitive Hashing-Based Biometric Template Protections</i><br>
-              <b><span style = "color : #DC143C">IEEE Transactions on Dependable and Secure Computing</span></b><br>
-          </li>
-      </ul>
-  </li>
-  <li>
-    (Mar 18, 2026) C&A Lab hosted the “MATH: Make AI Trust Higher” workshop at Hanyang University.
-    <details open>
-      <summary>
-        Poster: 
-      </summary>
-      <img src="./assets/Gallery/math_poster.png" alt="MATH Workshop" style="width:30%; max-width:600px; border-radius:10px;">
-    </details>
-  </li>
-  <li>
-      (Feb 5, 2026) Sunpill Kim will receive the <b><span style = "color : #08A709">Outstanding Ph.D. Dissertation Award</span></b> from Hanyang University.
-      <ul type="disc">
-          <li>
-             <b>Sunpill Kim</b><br><i>Score-Based Non-Adaptive Attack Against Face Recognition Systems</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-      (Jan 13, 2026) The following paper has been accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.
-      <ul type="disc">
-          <li>
-             <b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b><br><i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i> 
-          </li>
-      </ul>
-  </li>
-  <li>
-    (Jan 5, 2026) <b>Insoo Kim</b> (undergraduate student) joined Cryptology & Algorithm Lab, and we are pleased to welcome him to our Lab.
-  </li>
-</ul>    
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-red">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Paper</span>
+      <span class="cna-news-date">Apr 13, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.<br>
+      <b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b><br>
+      <i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-blue">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Paper</span>
+      <span class="cna-news-date">Apr 10, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Accepted for publication at <b><span style = "color : #4169E1">ACM CCS 2026</span></b>.<br>
+      <b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b><br>
+      <i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-amber">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Program</span>
+      <span class="cna-news-date">Apr 9, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      <b>Yunki Kim</b> has been selected for the National Cryptographic Expert Training Program (NACET) 12th cohort.
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-green">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Award</span>
+      <span class="cna-news-date">Apr 3, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Selected <b><span style = "color : #08A709">Outstanding Paper</span></b> at Hanyang University.<br>
+      <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim,</b> and <b>Jae Hong Seo*</b><br>
+      <i>On the Reversibility of Locality-Sensitive Hashing-Based Biometric Template Protections</i><br>
+      <b><span style = "color : #DC143C">IEEE Transactions on Dependable and Secure Computing</span></b>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-green">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Workshop</span>
+      <span class="cna-news-date">Mar 18, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      C&amp;A Lab hosted the “MATH: Make AI Trust Higher” workshop at Hanyang University.
+      <details open>
+        <summary>Poster</summary>
+        <img src="./assets/Gallery/math_poster.png" alt="MATH Workshop" style="width:30%; max-width:600px; border-radius:10px;">
+      </details>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-green">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Award</span>
+      <span class="cna-news-date">Feb 5, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Sunpill Kim will receive the <b><span style = "color : #08A709">Outstanding Ph.D. Dissertation Award</span></b> from Hanyang University.<br>
+      <b>Sunpill Kim</b><br>
+      <i>Score-Based Non-Adaptive Attack Against Face Recognition Systems</i>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-red">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Paper</span>
+      <span class="cna-news-date">Jan 13, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      Accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.<br>
+      <b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b><br>
+      <i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i>
+    </div>
+  </article>
+
+  <article class="cna-news-card cna-neutral">
+    <header class="cna-news-head">
+      <span class="cna-news-chip">Member</span>
+      <span class="cna-news-date">Jan 5, 2026</span>
+    </header>
+    <div class="cna-news-body">
+      <b>Insoo Kim</b> (undergraduate student) joined Cryptology &amp; Algorithm Lab, and we are pleased to welcome him to our Lab.
+    </div>
+  </article>
+
+</div>
 
 ## Seminar
 

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <time class="cna-card-meta">May 29, 2026</time>
     </header>
     <div class="cna-card-body">
-      <p>Prof. Taeho Jung from the University of Notre Dame will visit the C&amp;A Lab for a research-topic exchange.</p>
+      <p>Prof. Taeho Jung from the University of Notre Dame will visit the C&amp;A Lab for an academic exchange and research collaboration.</p>
       <ul>
         <li>Date &amp; Place: 01:00 PM, May 29 / Natural Science Building 702</li>
       </ul>

--- a/index.md
+++ b/index.md
@@ -152,7 +152,10 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
 </div>
 
-## Seminar
+<header class="cna-section-head" markdown="0" style="margin-top:var(--cna-s-8);">
+  <h2 style="margin:0;">Seminar</h2>
+  <a class="cna-section-action" href="mailto:jaehongseo@hanyang.ac.kr">Interested in joining the lab? ↗</a>
+</header>
 
 <details class="cna-year" open markdown="0">
   <summary>

--- a/index.md
+++ b/index.md
@@ -17,9 +17,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
 <div class="cna-card-grid" markdown="0">
 
-  <article class="cna-card cna-cat-talk">
+  <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-talk">Seminar</span>
+      <span class="cna-chip cna-chip-seminar">Seminar</span>
       <time class="cna-card-meta">May 20, 2026</time>
     </header>
     <div class="cna-card-body">
@@ -41,9 +41,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
     </div>
   </article>
 
-  <article class="cna-card cna-cat-talk">
+  <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-talk">Seminar</span>
+      <span class="cna-chip cna-chip-seminar">Seminar</span>
       <time class="cna-card-meta">Apr 20, 2026</time>
     </header>
     <div class="cna-card-body">
@@ -163,9 +163,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Apr 24 · 10:00–12:00</span>
+          <span class="cna-chip cna-chip-seminar">Apr 24 · 10:00–12:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1sM5iu_cBU5L2uL7pHeDBTwneX_Bg4jXQ/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -174,9 +174,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 8 · 10:00–12:00</span>
+          <span class="cna-chip cna-chip-seminar">May 8 · 10:00–12:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/13wY5T6epOOkcCL5_ssNvwXij1vV_PnOG/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -185,9 +185,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 15 · 10:00–12:00</span>
+          <span class="cna-chip cna-chip-seminar">May 15 · 10:00–12:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1WkHs5Uy_McSIr7bRCPyiTmF3gE1I-wVC/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -196,9 +196,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 22 · 10:00–12:00</span>
+          <span class="cna-chip cna-chip-seminar">May 22 · 10:00–12:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1Wh3zIBRhfLKzUfu63uv_8mjjPbg0zH-n/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -221,9 +221,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
     <p style="font-size:var(--cna-fs-sm); color:var(--cna-soft); margin:0 0 var(--cna-s-4);">Textbook: <b>Probabilistic Machine Learning: An Introduction</b> — Kevin P. Murphy · reading the Introduction chapters in order, weekly.</p>
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 7 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">May 7 · 17:30–19:30</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -232,9 +232,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 14 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">May 14 · 17:30–19:30</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -243,9 +243,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 21 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">May 21 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -254,9 +254,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">May 28 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">May 28 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -265,9 +265,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jun 4 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 4 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -276,9 +276,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jun 11 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 11 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -287,9 +287,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jun 18 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 18 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -298,9 +298,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jun 25 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 25 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -309,9 +309,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jul 2 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 2 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -320,9 +320,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jul 9 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 9 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -331,9 +331,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jul 16 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 16 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -342,9 +342,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jul 23 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 23 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -366,9 +366,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Oct 28 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Oct 28 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1QNgRDw9ERUpE5RE5WWAqn2EZQlDVYWGp/edit?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -377,9 +377,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Nov 4 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Nov 4 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1YTHaWFmVZIUODyBws5ZfeZSj7nOdVRaC/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -388,9 +388,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Nov 11 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Nov 11 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1NVu4nUIF6_u9aC36J4DEZlSTkwC2MPbs/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -399,9 +399,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Dec 23 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Dec 23 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/13gLW3crvea7GIHrpZY5iVTQqsRxHpwMM/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -410,9 +410,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Dec 30 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Dec 30 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1sU9C-VqUJrCv3GKU2yzRUzehppl7dSqa/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -421,9 +421,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 20 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 20 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1qrZLVDSDH1Jnz786wxLPAKgzevVDES4g/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -432,9 +432,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 27 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 27 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1ASTvISgJnNibQ7PfYpWzZB78NSYTlE9A/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -443,9 +443,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Feb 3 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Feb 3 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1hcxGaG-8ti89eL0xT_usKV3KOE6bogPS/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -454,9 +454,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Feb 10 · 13:00–15:00</span>
+          <span class="cna-chip cna-chip-seminar">Feb 10 · 13:00–15:00</span>
           <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1OopQk8i_0PNLCAc-yiRvX1ou0i0oL3Up/edit?usp=drive_link&ouid=100777603672304406865&rtpof=true&sd=true" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -478,9 +478,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
   <div class="cna-year-body">
     <div class="cna-card-grid">
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 9 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 9 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1BzkwDkWaLdJNY_iQfkgUrWzhFKjEbCup/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -489,9 +489,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 16 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 16 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1vODf9nSWAqCdwTNEwgGnq6wrFNUeC76G/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -500,9 +500,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 23 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 23 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1eMt4R282vJZm3DY4M8eu18tS1IOE16xL/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -511,9 +511,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Jan 30 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Jan 30 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1UejcLgoOcDlwej9KvKEnra5H76WCTrIx/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -522,9 +522,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Feb 13 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Feb 13 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1rYy2lJHrGeh2ph2CZpZ1M4YoL7gFsmHA/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
@@ -533,9 +533,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
         </div>
       </article>
 
-      <article class="cna-card cna-cat-talk">
+      <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-talk">Feb 20 · 15:00–17:00</span>
+          <span class="cna-chip cna-chip-seminar">Feb 20 · 15:00–17:00</span>
           <a class="cna-card-meta" href="https://drive.google.com/file/d/1bBP6nv34Sq8IGNBXLM4olqK7s9cxB0J4/view" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ author_profile: false
 excerpt: ''
 header:
   overlay_image: /assets/images/hyu1.png
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
+  overlay_filter: "rgba(31, 25, 20, 0.55)" # warm-tinted overlay matching the card surfaces
 ---
 
 # About us

--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
   <article class="cna-card cna-cat-paper">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-paper">Paper</span>
+      <span class="cna-chip cna-chip-paper">Journal</span>
       <time class="cna-card-meta">Apr 13, 2026</time>
     </header>
     <div class="cna-card-body">
@@ -67,9 +67,9 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
     </div>
   </article>
 
-  <article class="cna-card cna-cat-paper">
+  <article class="cna-card cna-cat-talk">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-paper">Paper</span>
+      <span class="cna-chip cna-chip-talk">Conference</span>
       <time class="cna-card-meta">Apr 10, 2026</time>
     </header>
     <div class="cna-card-body">
@@ -130,7 +130,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
   <article class="cna-card cna-cat-paper">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-paper">Paper</span>
+      <span class="cna-chip cna-chip-paper">Journal</span>
       <time class="cna-card-meta">Jan 13, 2026</time>
     </header>
     <div class="cna-card-body">

--- a/index.md
+++ b/index.md
@@ -246,7 +246,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">May 21 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 2 &amp; 3 · Probability: Univariate &amp; Multivariate Models</b><br>
@@ -257,7 +257,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">May 28 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
@@ -268,7 +268,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jun 4 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 9 &amp; 10 · Linear Discriminant Analysis &amp; Logistic Regression</b><br>
@@ -279,7 +279,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jun 11 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 11 · Linear Regression</b><br>
@@ -290,7 +290,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jun 18 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 13 · Neural Networks for Tabular Data</b><br>
@@ -301,7 +301,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jun 25 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 14 · Neural Networks for Images</b><br>
@@ -312,7 +312,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jul 2 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 15 · Neural Networks for Sequences</b><br>
@@ -323,7 +323,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jul 9 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 17 · Kernel Methods</b><br>
@@ -334,7 +334,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jul 16 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 19 · Learning with Fewer Labeled Examples</b><br>
@@ -345,7 +345,7 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
       <article class="cna-card cna-cat-talk">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-talk">Jul 23 · 17:30–19:30</span>
-          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
           <b>Ch 20 &amp; 21 · Dimensionality Reduction &amp; Clustering</b><br>

--- a/index.md
+++ b/index.md
@@ -15,174 +15,137 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
 ## Annual News
 
-<style type="text/css">
-.cna-news{ display:grid; gap:14px; grid-template-columns:1fr; margin:8px 0 28px; }
-.cna-news-card{
-  background:#fff; border:1px solid #e6e2d8; border-radius:14px;
-  padding:16px 20px;
-  box-shadow:0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
-  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
-}
-.cna-news-card:hover{
-  transform:translateY(-2px);
-  box-shadow:0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
-}
-.cna-news-head{
-  display:flex; align-items:baseline; justify-content:space-between;
-  gap:12px; margin-bottom:8px; flex-wrap:wrap;
-}
-.cna-news-chip{
-  font-size:11px; font-weight:600; letter-spacing:.12em;
-  text-transform:uppercase; padding:4px 10px; border-radius:999px; white-space:nowrap;
-}
-.cna-news-date{ font-size:12.5px; color:#8a909a; white-space:nowrap; font-weight:500; }
-.cna-news-body{ font-size:15px; color:#1f2227; line-height:1.6; }
-.cna-news-body ul{ margin:6px 0 0; padding-left:1.2em; }
-.cna-news-body details summary{ cursor:pointer; color:#52575f; font-size:13.5px; }
+<div class="cna-card-grid" markdown="0">
 
-.cna-red     .cna-news-chip{ background:#fbe7eb; color:#b6102d; }
-.cna-red:hover    { border-color:#DC143C; }
-.cna-blue    .cna-news-chip{ background:#eaf1fa; color:#2b5285; }
-.cna-blue:hover   { border-color:#4169E1; }
-.cna-green   .cna-news-chip{ background:#e8f4ee; color:#176549; }
-.cna-green:hover  { border-color:#08A709; }
-.cna-amber   .cna-news-chip{ background:#fdf4e3; color:#b8740a; }
-.cna-amber:hover  { border-color:#b8740a; }
-.cna-neutral .cna-news-chip{ background:#eeece7; color:#52575f; }
-.cna-neutral:hover{ border-color:#8a909a; }
-</style>
-
-<div class="cna-news" markdown="0">
-
-  <article class="cna-news-card cna-blue">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Seminar</span>
-      <span class="cna-news-date">May 20, 2026</span>
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Seminar</span>
+      <time class="cna-card-meta">May 20, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Prof. Yongha Son from Sungshin Women’s University will visit the C&amp;A Lab and give a lecture.
-      <ul type="disc">
+    <div class="cna-card-body">
+      <p>Prof. Yongha Son from Sungshin Women’s University will visit the C&amp;A Lab and give a lecture.</p>
+      <ul>
         <li>Date &amp; Place: 01:30 PM, May 21 / Natural Science Building 102</li>
         <li>Title: Private Set Intersection</li>
       </ul>
     </div>
   </article>
 
-  <article class="cna-news-card cna-neutral">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Member</span>
-      <span class="cna-news-date">May 4, 2026</span>
+  <article class="cna-card cna-cat-people">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-people">Member</span>
+      <time class="cna-card-meta">May 4, 2026</time>
     </header>
-    <div class="cna-news-body">
+    <div class="cna-card-body">
       Two undergraduate students <b>Hyeonmin Jang</b> and <b>Ingeun Yun</b> joined our Cryptology &amp; Algorithm Lab. We are delighted to welcome them.
     </div>
   </article>
 
-  <article class="cna-news-card cna-blue">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Seminar</span>
-      <span class="cna-news-date">Apr 20, 2026</span>
+  <article class="cna-card cna-cat-talk">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-talk">Seminar</span>
+      <time class="cna-card-meta">Apr 20, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Dr. Keewoo Lee from the Ethereum Foundation visited the C&amp;A Lab and gave a lecture.
-      <ul type="disc">
+    <div class="cna-card-body">
+      <p>Dr. Keewoo Lee from the Ethereum Foundation visited the C&amp;A Lab and gave a lecture.</p>
+      <ul>
         <li>Date &amp; Place: 01:00 PM, Apr 20 / Natural Science Building 702</li>
         <li>Title: Private Information Retrieval</li>
       </ul>
     </div>
   </article>
 
-  <article class="cna-news-card cna-red">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Paper</span>
-      <span class="cna-news-date">Apr 13, 2026</span>
+  <article class="cna-card cna-cat-paper">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-paper">Paper</span>
+      <time class="cna-card-meta">Apr 13, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.<br>
-      <b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b><br>
-      <i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i>
+    <div class="cna-card-body">
+      <p>Accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.</p>
+      <p><b>Minsu Kim&dagger;</b>, <b>Seunghun Paik&dagger;</b>, <b>Seongae Baek</b>, <b>Sangyoon Shin</b>, <b>Sunpill Kim</b>, and <b>Jae Hong Seo*</b><br>
+      <i>SilverMask: Face Template Protection with Fine-Grained Noise Correction</i></p>
     </div>
   </article>
 
-  <article class="cna-news-card cna-blue">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Paper</span>
-      <span class="cna-news-date">Apr 10, 2026</span>
+  <article class="cna-card cna-cat-paper">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-paper">Paper</span>
+      <time class="cna-card-meta">Apr 10, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Accepted for publication at <b><span style = "color : #4169E1">ACM CCS 2026</span></b>.<br>
-      <b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b><br>
-      <i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i>
+    <div class="cna-card-body">
+      <p>Accepted for publication at <b style="color:var(--cna-indigo)">ACM CCS 2026</b>.</p>
+      <p><b>Seunghun Paik&dagger;</b>, <b>Sunpill Kim&dagger;</b>, <b>Chanwoo Hwang</b>, and <b>Jae Hong Seo*</b><br>
+      <i>Casting the Net! Revisiting MasterFace Impersonation Attacks</i></p>
     </div>
   </article>
 
-  <article class="cna-news-card cna-amber">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Program</span>
-      <span class="cna-news-date">Apr 9, 2026</span>
+  <article class="cna-card cna-cat-event">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-event">Program</span>
+      <time class="cna-card-meta">Apr 9, 2026</time>
     </header>
-    <div class="cna-news-body">
+    <div class="cna-card-body">
       <b>Yunki Kim</b> has been selected for the National Cryptographic Expert Training Program (NACET) 12th cohort.
     </div>
   </article>
 
-  <article class="cna-news-card cna-green">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Award</span>
-      <span class="cna-news-date">Apr 3, 2026</span>
+  <article class="cna-card cna-cat-award">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-award">Award</span>
+      <time class="cna-card-meta">Apr 3, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Selected <b><span style = "color : #08A709">Outstanding Paper</span></b> at Hanyang University.<br>
-      <b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim,</b> and <b>Jae Hong Seo*</b><br>
+    <div class="cna-card-body">
+      <p>Selected <b style="color:var(--cna-forest)">Outstanding Paper</b> at Hanyang University.</p>
+      <p><b>Seunghun Paik</b>, <b>Chanwoo Hwang</b>, <b>Sunpill Kim,</b> and <b>Jae Hong Seo*</b><br>
       <i>On the Reversibility of Locality-Sensitive Hashing-Based Biometric Template Protections</i><br>
-      <b><span style = "color : #DC143C">IEEE Transactions on Dependable and Secure Computing</span></b>
+      <b style="color:var(--cna-crimson)">IEEE Transactions on Dependable and Secure Computing</b></p>
     </div>
   </article>
 
-  <article class="cna-news-card cna-green">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Workshop</span>
-      <span class="cna-news-date">Mar 18, 2026</span>
+  <article class="cna-card cna-cat-event">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-event">Workshop</span>
+      <time class="cna-card-meta">Mar 18, 2026</time>
     </header>
-    <div class="cna-news-body">
-      C&amp;A Lab hosted the “MATH: Make AI Trust Higher” workshop at Hanyang University.
+    <div class="cna-card-body">
+      <p>C&amp;A Lab hosted the “MATH: Make AI Trust Higher” workshop at Hanyang University.</p>
       <details open>
         <summary>Poster</summary>
-        <img src="./assets/Gallery/math_poster.png" alt="MATH Workshop" style="width:30%; max-width:600px; border-radius:10px;">
+        <img src="./assets/Gallery/math_poster.png" alt="MATH Workshop" style="width:50%; max-width:600px;">
       </details>
     </div>
   </article>
 
-  <article class="cna-news-card cna-green">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Award</span>
-      <span class="cna-news-date">Feb 5, 2026</span>
+  <article class="cna-card cna-cat-award">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-award">Award</span>
+      <time class="cna-card-meta">Feb 5, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Sunpill Kim will receive the <b><span style = "color : #08A709">Outstanding Ph.D. Dissertation Award</span></b> from Hanyang University.<br>
-      <b>Sunpill Kim</b><br>
-      <i>Score-Based Non-Adaptive Attack Against Face Recognition Systems</i>
+    <div class="cna-card-body">
+      <p>Sunpill Kim will receive the <b style="color:var(--cna-forest)">Outstanding Ph.D. Dissertation Award</b> from Hanyang University.</p>
+      <p><b>Sunpill Kim</b><br>
+      <i>Score-Based Non-Adaptive Attack Against Face Recognition Systems</i></p>
     </div>
   </article>
 
-  <article class="cna-news-card cna-red">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Paper</span>
-      <span class="cna-news-date">Jan 13, 2026</span>
+  <article class="cna-card cna-cat-paper">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-paper">Paper</span>
+      <time class="cna-card-meta">Jan 13, 2026</time>
     </header>
-    <div class="cna-news-body">
-      Accepted for publication at <b><span style = "color : #DC143C">IEEE Access</span></b>.<br>
-      <b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b><br>
-      <i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i>
+    <div class="cna-card-body">
+      <p>Accepted for publication at <b style="color:var(--cna-crimson)">IEEE Access</b>.</p>
+      <p><b>Hyeonbum Lee</b>, <b>Seunghun Paik</b>, <b>Hyunjung Son</b>, and <b>Jae Hong Seo*</b><br>
+      <i>Cougar: Cubic Root Verifier Inner Product Argument under Discrete Logarithm Assumption</i></p>
     </div>
   </article>
 
-  <article class="cna-news-card cna-neutral">
-    <header class="cna-news-head">
-      <span class="cna-news-chip">Member</span>
-      <span class="cna-news-date">Jan 5, 2026</span>
+  <article class="cna-card cna-cat-people">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-people">Member</span>
+      <time class="cna-card-meta">Jan 5, 2026</time>
     </header>
-    <div class="cna-news-body">
+    <div class="cna-card-body">
       <b>Insoo Kim</b> (undergraduate student) joined Cryptology &amp; Algorithm Lab, and we are pleased to welcome him to our Lab.
     </div>
   </article>
@@ -191,367 +154,400 @@ We are Cryptology & Algorithm Lab and our leader is Professor [Jae Hong Seo](htt
 
 ## Seminar
 
-<style type="text/css">
-/* OPTIONAL custom fonts — uncomment to enable
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=JetBrains+Mono:wght@400;500;600&display=swap');
-.cna-seminars .cna-head h2 { font-family:'Fraunces', serif !important; }
-.cna-seminars .cna-when .cna-date,
-.cna-seminars .cna-when .cna-time,
-.cna-seminars .cna-place,
-.cna-seminars .cna-count,
-.cna-seminars .cna-tag { font-family:'JetBrains Mono', monospace !important; }
-*/
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2026 · Spring / Summer Seminar</h3>
+    <span class="cna-year-count">4 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
 
-.cna-seminars{
-  --cna-ink:#1f2227;
-  --cna-soft:#52575f;
-  --cna-faint:#8a909a;
-  --cna-card:#ffffff;
-  --cna-line:#e6e2d8;
-  --cna-amber:#e39309;  --cna-amber-deep:#b8740a;  --cna-amber-wash:#fdf4e3;
-  --cna-green:#208560;  --cna-green-deep:#176549;  --cna-green-wash:#e8f4ee;
-  --cna-blue:#3b6fb5;   --cna-blue-deep:#2b5285;   --cna-blue-wash:#eaf1fa;
-  width:100%;
-}
-
-.cna-seminars .cna-seminar{ margin:0 0 18px; border:none; }
-
-/* ---- clickable header (summary) ---- */
-.cna-seminars .cna-head{
-  display:flex; align-items:center; gap:16px; flex-wrap:wrap;
-  list-style:none; cursor:pointer; user-select:none;
-  padding:12px 14px; border-radius:12px; transition:background .15s ease;
-}
-.cna-seminars .cna-head::-webkit-details-marker{ display:none; }
-.cna-seminars .cna-head:hover{ background:rgba(0,0,0,.025); }
-
-.cna-seminars .cna-tag{
-  font-size:11px; font-weight:600; letter-spacing:.12em; text-transform:uppercase;
-  padding:5px 11px; border-radius:999px; white-space:nowrap;
-}
-.cna-seminars .cna-head h2{
-  font-weight:600; font-size:1.05rem; letter-spacing:-.01em; margin:0; flex:1 1 auto;
-  border:none; padding:0;
-}
-.cna-seminars .cna-count{ font-size:13px; color:var(--cna-faint); white-space:nowrap; }
-.cna-seminars .cna-chevron{
-  width:20px; height:20px; flex:0 0 20px; color:var(--cna-faint); transition:transform .2s ease;
-}
-.cna-seminars details[open] .cna-chevron{ transform:rotate(180deg); }
-
-.cna-seminars .cna-amber .cna-tag{ background:var(--cna-amber-wash); color:var(--cna-amber-deep); }
-.cna-seminars .cna-amber .cna-bar{ background:linear-gradient(90deg,var(--cna-amber),var(--cna-amber-deep)); }
-.cna-seminars .cna-green .cna-tag{ background:var(--cna-green-wash); color:var(--cna-green-deep); }
-.cna-seminars .cna-green .cna-bar{ background:linear-gradient(90deg,var(--cna-green),var(--cna-green-deep)); }
-.cna-seminars .cna-blue .cna-tag{ background:var(--cna-blue-wash); color:var(--cna-blue-deep); }
-.cna-seminars .cna-blue .cna-bar{ background:linear-gradient(90deg,var(--cna-blue),var(--cna-blue-deep)); }
-
-.cna-seminars .cna-bar{ height:3px; border-radius:3px; margin:8px 0 10px; width:100%; }
-.cna-seminars .cna-note{
-  font-size:13px; color:var(--cna-soft); margin:0 4px 16px; padding-left:2px;
-  display:flex; align-items:center; gap:7px; flex-wrap:wrap;
-}
-.cna-seminars .cna-note b{ color:var(--cna-ink); font-weight:600; }
-
-.cna-seminars .cna-sessions{ display:flex; flex-direction:column; gap:10px; padding:0 4px; }
-
-.cna-seminars .cna-session{
-  display:grid; grid-template-columns:190px 1fr 150px 90px; gap:18px; align-items:center;
-  background:var(--cna-card); border:1px solid var(--cna-line); border-radius:14px;
-  padding:16px 20px;
-  box-shadow:0 1px 2px rgba(31,34,39,.04), 0 6px 18px rgba(31,34,39,.05);
-  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
-}
-.cna-seminars .cna-session:hover{
-  transform:translateY(-2px); box-shadow:0 4px 8px rgba(31,34,39,.06), 0 14px 34px rgba(31,34,39,.10);
-}
-.cna-seminars .cna-amber .cna-session:hover{ border-color:var(--cna-amber); }
-.cna-seminars .cna-green .cna-session:hover{ border-color:var(--cna-green); }
-.cna-seminars .cna-blue .cna-session:hover{ border-color:var(--cna-blue); }
-
-.cna-seminars .cna-when{ display:flex; flex-direction:column; gap:3px; }
-.cna-seminars .cna-when .cna-date{ font-weight:600; font-size:15px; color:var(--cna-ink); }
-.cna-seminars .cna-when .cna-time{ font-size:12px; color:var(--cna-faint); }
-
-.cna-seminars .cna-title{ font-weight:500; font-size:15px; color:var(--cna-ink); line-height:1.4; }
-.cna-seminars .cna-ch{ color:var(--cna-faint); font-weight:600; }
-
-.cna-seminars .cna-who{ display:flex; align-items:center; font-size:13.5px; }
-.cna-seminars .cna-who .cna-name{
-  display:inline-block; padding:6px 12px; border-radius:9px;
-  background:#eee9dd; color:var(--cna-soft); font-weight:600; line-height:1.3;
-}
-/* presenter chip tinted to each section's accent */
-.cna-seminars .cna-amber .cna-who .cna-name{ background:var(--cna-amber-wash); color:var(--cna-amber-deep); }
-.cna-seminars .cna-green .cna-who .cna-name{ background:var(--cna-green-wash); color:var(--cna-green-deep); }
-.cna-seminars .cna-blue  .cna-who .cna-name{ background:var(--cna-blue-wash);  color:var(--cna-blue-deep);  }
-.cna-seminars .cna-place{
-  font-size:11.5px; color:var(--cna-faint); margin-top:5px; display:flex; align-items:center; gap:5px;
-}
-.cna-seminars .cna-place::before{ content:""; width:5px; height:5px; border-radius:50%; background:var(--cna-faint); opacity:.6; }
-
-.cna-seminars .cna-mat{ justify-self:end; }
-.cna-seminars .cna-mat a{
-  display:inline-flex; align-items:center; gap:6px; font-weight:600; font-size:13px;
-  text-decoration:none; padding:8px 14px; border-radius:9px;
-  border:1px solid var(--cna-line); color:var(--cna-ink); transition:all .15s ease;
-}
-.cna-seminars .cna-mat a svg{ width:13px; height:13px; }
-.cna-seminars .cna-amber .cna-mat a:hover{ background:var(--cna-amber); border-color:var(--cna-amber); color:#fff; }
-.cna-seminars .cna-green .cna-mat a:hover{ background:var(--cna-green); border-color:var(--cna-green); color:#fff; }
-.cna-seminars .cna-blue .cna-mat a:hover{ background:var(--cna-blue); border-color:var(--cna-blue); color:#fff; }
-.cna-seminars .cna-tba{ font-size:12px; color:var(--cna-faint); }
-
-@media (max-width:760px){
-  .cna-seminars .cna-session{ grid-template-columns:1fr; gap:12px; padding:16px; }
-  .cna-seminars .cna-mat{ justify-self:start; }
-  .cna-seminars .cna-when{ flex-direction:row; align-items:baseline; gap:10px; }
-}
-</style>
-
-<div class="cna-seminars" markdown="0">
-
-  <details class="cna-seminar cna-amber" open>
-    <summary class="cna-head">
-      <span class="cna-tag">2026 · Spring / Summer</span>
-      <h2>Spring / Summer Seminar</h2>
-      <span class="cna-count">4 sessions</span>
-      <svg class="cna-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
-    </summary>
-    <div class="cna-bar"></div>
-    <div class="cna-sessions">
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Apr 24</span><span class="cna-time">10:00–12:00 KST</span></div>
-        <div><div class="cna-title">Deep Neural Cryptography</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Seunghun Paik</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1sM5iu_cBU5L2uL7pHeDBTwneX_Bg4jXQ/view?usp=sharing" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Apr 24 · 10:00–12:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1sM5iu_cBU5L2uL7pHeDBTwneX_Bg4jXQ/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Deep Neural Cryptography</b><br>
+          <span style="color:var(--cna-soft)">Seunghun Paik · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 8</span><span class="cna-time">10:00–12:00 KST</span></div>
-        <div><div class="cna-title">Towards Deep Conversational Recommendations</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Changjin Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/13wY5T6epOOkcCL5_ssNvwXij1vV_PnOG/view?usp=drive_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 8 · 10:00–12:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/13wY5T6epOOkcCL5_ssNvwXij1vV_PnOG/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Towards Deep Conversational Recommendations</b><br>
+          <span style="color:var(--cna-soft)">Changjin Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 15</span><span class="cna-time">10:00–12:00 KST</span></div>
-        <div><div class="cna-title">Denoising Diffusion Implicit Models</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1WkHs5Uy_McSIr7bRCPyiTmF3gE1I-wVC/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 15 · 10:00–12:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1WkHs5Uy_McSIr7bRCPyiTmF3gE1I-wVC/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Denoising Diffusion Implicit Models</b><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 22</span><span class="cna-time">10:00–12:00 KST</span></div>
-        <div><div class="cna-title">Concept-based Adversarial Attack: a Probabilistic Perspective</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Chanwoo Hwang</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1Wh3zIBRhfLKzUfu63uv_8mjjPbg0zH-n/view?usp=drive_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 22 · 10:00–12:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1Wh3zIBRhfLKzUfu63uv_8mjjPbg0zH-n/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Concept-based Adversarial Attack: a Probabilistic Perspective</b><br>
+          <span style="color:var(--cna-soft)">Chanwoo Hwang · Natural Building 702</span>
+        </div>
       </article>
+
     </div>
-  </details>
+  </div>
+</details>
 
-  <!-- ===== Probabilistic ML Study (ongoing, open) ===== -->
-  <details class="cna-seminar cna-blue" open>
-    <summary class="cna-head">
-      <span class="cna-tag">2026 · Spring · Study Group</span>
-      <h2>Probabilistic Machine Learning</h2>
-      <span class="cna-count">12 sessions</span>
-      <svg class="cna-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
-    </summary>
-    <div class="cna-bar"></div>
-    <p class="cna-note">Textbook: <b>Probabilistic Machine Learning: An Introduction</b> &mdash; Kevin P. Murphy &nbsp;·&nbsp; reading the Introduction chapters in order, weekly.</p>
-    <div class="cna-sessions">
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 7</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title">Linear Algebra &mdash; I <span class="cna-ch">(prerequisite)</span></div><div class="cna-place">Natural Building 742</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+<details class="cna-year" open markdown="0">
+  <summary>
+    <h3>2026 · Spring · Probabilistic ML Study Group</h3>
+    <span class="cna-year-count">12 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <p style="font-size:var(--cna-fs-sm); color:var(--cna-soft); margin:0 0 var(--cna-s-4);">Textbook: <b>Probabilistic Machine Learning: An Introduction</b> — Kevin P. Murphy · reading the Introduction chapters in order, weekly.</p>
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 7 · 17:30–19:30</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Linear Algebra — I</b> <span style="color:var(--cna-faint); font-size:var(--cna-fs-sm)">(prerequisite)</span><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Natural Building 742</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 14</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title">Linear Algebra &mdash; II <span class="cna-ch">(prerequisite)</span></div><div class="cna-place">Natural Building 742</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 14 · 17:30–19:30</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/12T2ylLOPioP-2JtE7tMk1RrBcj3HhM2Y/view?usp=share_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Linear Algebra — II</b> <span style="color:var(--cna-faint); font-size:var(--cna-fs-sm)">(prerequisite)</span><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Natural Building 742</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 21</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 2 &amp; 3 ·</span> Probability: Univariate &amp; Multivariate Models</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Ingeun Yun</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 21 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 2 &amp; 3 · Probability: Univariate &amp; Multivariate Models</b><br>
+          <span style="color:var(--cna-soft)">Ingeun Yun · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">May 28</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 4 &amp; 6 ·</span> Statistics &amp; Information Theory</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Insoo Kim</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">May 28 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
+          <span style="color:var(--cna-soft)">Insoo Kim · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jun 4</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 9 &amp; 10 ·</span> Linear Discriminant Analysis &amp; Logistic Regression</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Hyeonmin Jang</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jun 4 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 9 &amp; 10 · Linear Discriminant Analysis &amp; Logistic Regression</b><br>
+          <span style="color:var(--cna-soft)">Hyeonmin Jang · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jun 11</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 11 ·</span> Linear Regression</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Shinwoong Kwak</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jun 11 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 11 · Linear Regression</b><br>
+          <span style="color:var(--cna-soft)">Shinwoong Kwak · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jun 18</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 13 ·</span> Neural Networks for Tabular Data</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Ingeun Yun</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jun 18 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 13 · Neural Networks for Tabular Data</b><br>
+          <span style="color:var(--cna-soft)">Ingeun Yun · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jun 25</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 14 ·</span> Neural Networks for Images</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Insoo Kim</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jun 25 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 14 · Neural Networks for Images</b><br>
+          <span style="color:var(--cna-soft)">Insoo Kim · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jul 2</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 15 ·</span> Neural Networks for Sequences</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Hyeonmin Jang</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jul 2 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 15 · Neural Networks for Sequences</b><br>
+          <span style="color:var(--cna-soft)">Hyeonmin Jang · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jul 9</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 17 ·</span> Kernel Methods</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jul 9 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 17 · Kernel Methods</b><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jul 16</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 19 ·</span> Learning with Fewer Labeled Examples</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Shinwoong Kwak</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jul 16 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 19 · Learning with Fewer Labeled Examples</b><br>
+          <span style="color:var(--cna-soft)">Shinwoong Kwak · Place TBA</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jul 23</span><span class="cna-time">17:30–19:30 KST</span></div>
-        <div><div class="cna-title"><span class="cna-ch">Ch 20 &amp; 21 ·</span> Dimensionality Reduction &amp; Clustering</div><div class="cna-place">Place TBA</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><span class="cna-tba">TBA</span></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jul 23 · 17:30–19:30</span>
+          <span class="cna-card-meta" style="color:var(--cna-faint)">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 20 &amp; 21 · Dimensionality Reduction &amp; Clustering</b><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Place TBA</span>
+        </div>
       </article>
+
     </div>
-  </details>
+  </div>
+</details>
 
-  <!-- ===== 26 Spring / Summer (open) ===== -->
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2025 Fall · 2026 Winter Seminar</h3>
+    <span class="cna-year-count">9 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
 
-  <!-- ===== 25 Fall / 26 Winter (collapsed) ===== -->
-  <details class="cna-seminar cna-amber">
-    <summary class="cna-head">
-      <span class="cna-tag">2025 Fall · 2026 Winter</span>
-      <h2>Fall / Winter Seminar</h2>
-      <span class="cna-count">9 sessions</span>
-      <svg class="cna-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
-    </summary>
-    <div class="cna-bar"></div>
-    <div class="cna-sessions">
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Oct 28</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">Fuzzy Private Set Intersection from VOLE</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Yunki Kim</span></div>
-        <div class="cna-mat"><a href="https://docs.google.com/presentation/d/1QNgRDw9ERUpE5RE5WWAqn2EZQlDVYWGp/edit?usp=sharing" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Oct 28 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1QNgRDw9ERUpE5RE5WWAqn2EZQlDVYWGp/edit?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Fuzzy Private Set Intersection from VOLE</b><br>
+          <span style="color:var(--cna-soft)">Yunki Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Nov 4</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">Non-Interactive Multiplication and More</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Seunghun Paik</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1YTHaWFmVZIUODyBws5ZfeZSj7nOdVRaC/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Nov 4 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1YTHaWFmVZIUODyBws5ZfeZSj7nOdVRaC/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Non-Interactive Multiplication and More</b><br>
+          <span style="color:var(--cna-soft)">Seunghun Paik · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Nov 11</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">ICCV 2025 (Conference Review)</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Changjin Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1NVu4nUIF6_u9aC36J4DEZlSTkwC2MPbs/view?usp=drive_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Nov 11 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1NVu4nUIF6_u9aC36J4DEZlSTkwC2MPbs/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>ICCV 2025 (Conference Review)</b><br>
+          <span style="color:var(--cna-soft)">Changjin Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Dec 23</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">NeurIPS 2025 (Conference Review)</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/13gLW3crvea7GIHrpZY5iVTQqsRxHpwMM/view?usp=sharing" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Dec 23 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/13gLW3crvea7GIHrpZY5iVTQqsRxHpwMM/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>NeurIPS 2025 (Conference Review)</b><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Dec 30</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Introduction to Text-to-Image Models</div><div class="cna-place">Natural Building 746</div></div>
-        <div class="cna-who"><span class="cna-name">Chanwoo Hwang</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1sU9C-VqUJrCv3GKU2yzRUzehppl7dSqa/view?usp=drive_link" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Dec 30 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1sU9C-VqUJrCv3GKU2yzRUzehppl7dSqa/view?usp=drive_link" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Introduction to Text-to-Image Models</b><br>
+          <span style="color:var(--cna-soft)">Chanwoo Hwang · Natural Building 746</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 20</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Implicit Bias of SGD in L2-regularized Linear DNNs: One-way Jumps from High to Low Rank</div><div class="cna-place">Natural Building B119</div></div>
-        <div class="cna-who"><span class="cna-name">Dongsoo Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1qrZLVDSDH1Jnz786wxLPAKgzevVDES4g/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 20 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1qrZLVDSDH1Jnz786wxLPAKgzevVDES4g/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Implicit Bias of SGD in L2-regularized Linear DNNs: One-way Jumps from High to Low Rank</b><br>
+          <span style="color:var(--cna-soft)">Dongsoo Kim · Natural Building B119</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 27</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">Mamba: Linear-Time Sequence Modeling with Selective State Spaces</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Hyunjung Son</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1ASTvISgJnNibQ7PfYpWzZB78NSYTlE9A/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 27 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1ASTvISgJnNibQ7PfYpWzZB78NSYTlE9A/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Mamba: Linear-Time Sequence Modeling with Selective State Spaces</b><br>
+          <span style="color:var(--cna-soft)">Hyunjung Son · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Feb 3</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">Back to Basics: Let Denoising Generative Models Denoise</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Insoo Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1hcxGaG-8ti89eL0xT_usKV3KOE6bogPS/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Feb 3 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1hcxGaG-8ti89eL0xT_usKV3KOE6bogPS/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Back to Basics: Let Denoising Generative Models Denoise</b><br>
+          <span style="color:var(--cna-soft)">Insoo Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Feb 10</span><span class="cna-time">13:00–15:00 KST</span></div>
-        <div><div class="cna-title">Subspace Collision: An Efficient &amp; Accurate Framework for High-dimensional Approximate Nearest Neighbor Search</div><div class="cna-place">Natural Building 701</div></div>
-        <div class="cna-who"><span class="cna-name">Yunki Kim</span></div>
-        <div class="cna-mat"><a href="https://docs.google.com/presentation/d/1OopQk8i_0PNLCAc-yiRvX1ou0i0oL3Up/edit?usp=drive_link&ouid=100777603672304406865&rtpof=true&sd=true" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Feb 10 · 13:00–15:00</span>
+          <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1OopQk8i_0PNLCAc-yiRvX1ou0i0oL3Up/edit?usp=drive_link&ouid=100777603672304406865&rtpof=true&sd=true" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Subspace Collision: An Efficient &amp; Accurate Framework for High-dimensional Approximate Nearest Neighbor Search</b><br>
+          <span style="color:var(--cna-soft)">Yunki Kim · Natural Building 701</span>
+        </div>
       </article>
+
     </div>
-  </details>
+  </div>
+</details>
 
-  <!-- ===== 26 Winter Special Topic: VLMs (collapsed) ===== -->
-  <details class="cna-seminar cna-green">
-    <summary class="cna-head">
-      <span class="cna-tag">2026 Winter · Special Topic</span>
-      <h2>Vision Language Models (VLMs)</h2>
-      <span class="cna-count">6 sessions</span>
-      <svg class="cna-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
-    </summary>
-    <div class="cna-bar"></div>
-    <div class="cna-sessions">
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 9</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Introduction to (Large) Language Models</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Seunghun Paik</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1BzkwDkWaLdJNY_iQfkgUrWzhFKjEbCup/view?usp=sharing" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+<details class="cna-year" markdown="0">
+  <summary>
+    <h3>2026 Winter · Special Topic: Vision Language Models</h3>
+    <span class="cna-year-count">6 sessions</span>
+    <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
+  </summary>
+  <div class="cna-year-body">
+    <div class="cna-card-grid">
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 9 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1BzkwDkWaLdJNY_iQfkgUrWzhFKjEbCup/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Introduction to (Large) Language Models</b><br>
+          <span style="color:var(--cna-soft)">Seunghun Paik · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 16</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Learning Transferable Visual Models from Natural Language Supervision (CLIP)</div><div class="cna-place">Natural Building B119</div></div>
-        <div class="cna-who"><span class="cna-name">Changjin Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1vODf9nSWAqCdwTNEwgGnq6wrFNUeC76G/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 16 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1vODf9nSWAqCdwTNEwgGnq6wrFNUeC76G/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Learning Transferable Visual Models from Natural Language Supervision (CLIP)</b><br>
+          <span style="color:var(--cna-soft)">Changjin Kim · Natural Building B119</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 23</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">CLIP Variants</div><div class="cna-place">Natural Building B119</div></div>
-        <div class="cna-who"><span class="cna-name">Minsu Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1eMt4R282vJZm3DY4M8eu18tS1IOE16xL/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 23 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1eMt4R282vJZm3DY4M8eu18tS1IOE16xL/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>CLIP Variants</b><br>
+          <span style="color:var(--cna-soft)">Minsu Kim · Natural Building B119</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Jan 30</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Mind the Gap: About Modality Gap</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Chanwoo Hwang</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1UejcLgoOcDlwej9KvKEnra5H76WCTrIx/view?usp=sharing" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Jan 30 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1UejcLgoOcDlwej9KvKEnra5H76WCTrIx/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Mind the Gap: About Modality Gap</b><br>
+          <span style="color:var(--cna-soft)">Chanwoo Hwang · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Feb 13</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">Attack Methods for CLIP and Vision–Language Pre-trained Models</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Dongsoo Kim</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1rYy2lJHrGeh2ph2CZpZ1M4YoL7gFsmHA/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Feb 13 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1rYy2lJHrGeh2ph2CZpZ1M4YoL7gFsmHA/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>Attack Methods for CLIP and Vision–Language Pre-trained Models</b><br>
+          <span style="color:var(--cna-soft)">Dongsoo Kim · Natural Building 702</span>
+        </div>
       </article>
-      <article class="cna-session">
-        <div class="cna-when"><span class="cna-date">Feb 20</span><span class="cna-time">15:00–17:00 KST</span></div>
-        <div><div class="cna-title">BLIP, BLIP2, and Flamingo</div><div class="cna-place">Natural Building 702</div></div>
-        <div class="cna-who"><span class="cna-name">Seunghun Paik</span></div>
-        <div class="cna-mat"><a href="https://drive.google.com/file/d/1bBP6nv34Sq8IGNBXLM4olqK7s9cxB0J4/view" target="_blank" rel="noopener">Slides<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M7 17L17 7M17 7H8M17 7v9"/></svg></a></div>
+
+      <article class="cna-card cna-cat-talk">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-talk">Feb 20 · 15:00–17:00</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/1bBP6nv34Sq8IGNBXLM4olqK7s9cxB0J4/view" target="_blank" rel="noopener">Slides ↗</a>
+        </header>
+        <div class="cna-card-body">
+          <b>BLIP, BLIP2, and Flamingo</b><br>
+          <span style="color:var(--cna-soft)">Seunghun Paik · Natural Building 702</span>
+        </div>
       </article>
+
     </div>
-  </details>
-
-</div>
+  </div>
+</details>
 
 ## Contact
-For any inquires, you can reach us via email: **jaehongseo@hanyang.ac.kr**
+
+For any inquiries, you can reach us via email: **jaehongseo@hanyang.ac.kr**

--- a/index.md
+++ b/index.md
@@ -33,7 +33,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
     <div class="cna-card-body">
       <p>Prof. Taeho Jung from the University of Notre Dame will visit the C&amp;A Lab for a research-topic exchange.</p>
       <ul>
-        <li>Date &amp; Place: 01:00 PM – 04:00 PM, May 29 / Natural Science Building 702</li>
+        <li>Date &amp; Place: 01:00 PM, May 29 / Natural Science Building 702</li>
       </ul>
     </div>
   </article>


### PR DESCRIPTION
## Summary

A full visual refresh of the lab homepage. Every content page (`index.md` and all 8 `_pages/*.md`) has been migrated onto a single shared design system in `_includes/head/custom.html`. The substance — every paper, member, award, project, photo — is preserved verbatim; only the wrapper, typography, and layout change.

## Design system foundations

- **Single source of truth**: `_includes/head/custom.html` (~1000 lines) holds CSS tokens + 14 component primitives. Per-page `<style>` blocks removed.
- **5-color semantic palette** (1 color → 1 meaning across the whole site):
  - 🔴 **Crimson** — Journal world (journal venue chips, paper-acceptance news with journal venue)
  - 🔵 **Indigo** — Conference world (conference venue chips, conference paper accepts, conference attendance)
  - 🟣 **Plum** — Seminar world (lab seminars, study groups, visiting talks, invited lectures, interviews)
  - 🟢 **Forest** — Award & honor
  - 🟠 **Amber** — Event/grant (workshops hosted, NRF/IITP/etc. grants, fellowships, program selections)
  - ⚪ **Stone** — Neutral (members, press coverage, research topics)
- **Typography scale**: 12 / 14 / 16 / 17 / 19 / 22 / 26 / 28 px; body bumped from 13.5–14.5 → 16, Yesteryear motto replaced by Caveat at 28px for readability.
- **Components**: `.cna-card`, `.cna-chip`, `.cna-year` (collapsible), `.cna-row` (id | content | aside grid), `.cna-roster`/`.cna-member`, `.cna-tally`, `.cna-photo-grid`, `.cna-prose`, `.cna-section-head`, `.cna-page-toc`.

## Per-page changes

- **`index.md`** — Annual News flat `<ul>` → card grid with category chips (Journal / Conference / Seminar / Award / Workshop / Program / Member). The Seminar section (4 collapsible seasons, 31 sessions) is now part of the same card system. Floating section TOC (About us / Annual News / Seminar / Contact) appears on the right above 1280px viewport with scrollspy. \"Interested in joining the lab?\" mailto link on the Seminar header.
- **`_pages/Publication.md`** — 65 entries (34 journal + 31 conference) in collapsible year clusters with `[J##]`/`[C##]` id badges and color-coded venue chips. Floating TOC (Journal / Conference).
- **`_pages/Members.md`** — Active members as expandable cards (responsive auto-fit grid). Click-to-expand on multi-card sections; Prof card opens by default with a 2-column inner layout (summary + Education/Interests bio) above 1024px. Alumni grouped in collapsed `<details>` per category. Floating TOC.
- **`_pages/Interest.md`** — 4 research areas as `.cna-section` blocks with stone accent (a single neutral color so research topics don't visually collide with the venue-chip palette). Full-width prose with collapsible \"learn more\" boxes. Floating TOC.
- **`_pages/Projects.md`** — 26 projects (4 ongoing + 22 finished) as rows with period + Korean/English titles + neutral funder chips. Finished projects clustered into era `.cna-year` blocks. CRYPTOLAB labelled as (주)크립토랩.
- **`_pages/honer_award.md`** — 23 awards across 8 years in year clusters. Each row splits institution and recipients onto two visually distinct lines via `.cna-row-recipients`. Uniform forest chip per award (tier in chip text).
- **`_pages/media.md`** — 23 newspaper articles in year clusters + 5 video cards. Korean press headlines preserved verbatim.
- **`_pages/Previous events.md`** — 182 archived items ported onto the same card system as Annual News, year-clustered. 18 conference paper accepts in indigo, 111 seminar/lecture sessions in plum, 24 papers split journal/conference per venue.
- **`_pages/Gallery.md`** — 18 photo galleries grouped into 5 year-clusters with descriptive section headings and category chips. Minimal-mistakes `{% include gallery %}` rendering preserved.

## Chrome and navigation

- **Hero**: title 2rem 800 with uppercase eyebrow `CRYPTOLOGY & ALGORITHM LAB · HANYANG UNIVERSITY` above each page header. Warm-tinted overlay `rgba(31,25,20,0.55)` standardized across all 9 pages.
- **Masthead**: `masthead_title` set to \"C&A Lab\". Active page link gets indigo color + bold + 2px indigo underline (overrides the cached include bug).
- **Sidebar nav** (News sub-pages): active item highlighted by text color + weight only (no rectangle background).
- **Floating section TOC**: scrollspy-driven widget on 4 pages (Home / Publications / Interest / Members). IntersectionObserver-based, smooth scroll on click, hidden below 1280px.
- **External links**: small JS in `_includes/footer/custom.html` auto-adds `target=\"_blank\" rel=\"noopener noreferrer\"` to all off-site links so the lab homepage stays open.
- **Footer**: lab identity (department / university / PI / email) replaces the generic Jekyll/Minimal Mistakes credit.

## What is preserved exactly

- Every paper, member, award, project, press article, gallery photo, motto, link, and venue label.
- The misspelled `honer_award.md` filename (URL depends on it).
- minimal-mistakes theme structure; only overrides via `_includes/head/custom.html`, `_includes/footer/custom.html`, `_includes/masthead.html`, `_includes/footer.html`, `_includes/nav_list`, `_layouts/default.html`, and `_data/navigation.yml`.

## Test plan

- [ ] Pull the branch locally and run `bundle exec jekyll serve --livereload`
- [ ] Visit each page (`/`, `/Members/`, `/Publications/`, `/Projects/`, `/Interest/`, `/News/honor_award/`, `/News/media/`, `/News/previous_event/`, `/News/Gallery/`) — confirm content matches expectation
- [ ] Click the active nav link per page — confirm correct page is highlighted
- [ ] Scroll on the homepage / Publications / Interest / Members and watch the floating TOC track sections
- [ ] Open the Professor card on `/Members/` — confirm Education + Research Interests render in the right-side column
- [ ] Click an Integrated/Undergrad member card on `/Members/` — confirm it expands to span the full row
- [ ] Click any DOI / external slide link — confirm it opens in a new tab
- [ ] Click sub-page links in the News sidebar — confirm the current page shows the indigo+bold text color
- [ ] Resize the browser narrow (<760px) — confirm cards stack 1-column, TOC hides, layout doesn't break

## Branch

`Chan-Woo-H:design/general-refresh-20260523` — 30 commits ahead of `Cryptology-Algorithm-Lab:master`.