### PR TITLE
Add lab GitHub link to footer and unify HUCC link as matching pill

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,5 +1,15 @@
 <!-- start custom footer snippets -->
-<p align="right"><A href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer"><img src="/assets/images/hucc.png"></A></p>
+<p align="right" style="display:flex; justify-content:flex-end; align-items:center; gap:18px; margin:0;">
+  <a href="https://github.com/Cryptology-Algorithm-Lab" target="_blank" rel="noopener noreferrer"
+     title="Cryptology & Algorithm Lab on GitHub"
+     style="display:inline-flex; align-items:center; gap:8px; padding:8px 14px; border:1px solid var(--cna-line); border-radius:999px; color:var(--cna-ink); text-decoration:none; font-size:14px; font-weight:600; background:var(--cna-paper); transition:border-color .18s ease, color .18s ease;">
+    <i class="fab fa-github" style="font-size:18px;"></i>
+    <span>Cryptology-Algorithm-Lab</span>
+  </a>
+  <a href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer">
+    <img src="/assets/images/hucc.png">
+  </a>
+</p>
 
 <script>
 (function () {

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,15 +1,39 @@
 <!-- start custom footer snippets -->
-<p align="right" style="display:flex; justify-content:flex-end; align-items:center; gap:18px; margin:0;">
+<p align="right" style="display:flex; justify-content:flex-end; align-items:center; gap:12px; margin:0;">
   <a href="https://github.com/Cryptology-Algorithm-Lab" target="_blank" rel="noopener noreferrer"
      title="Cryptology & Algorithm Lab on GitHub"
-     style="display:inline-flex; align-items:center; gap:8px; padding:8px 14px; border:1px solid var(--cna-line); border-radius:999px; color:var(--cna-ink); text-decoration:none; font-size:14px; font-weight:600; background:var(--cna-paper); transition:border-color .18s ease, color .18s ease;">
+     class="cna-footer-pill">
     <i class="fab fa-github" style="font-size:18px;"></i>
     <span>Cryptology-Algorithm-Lab</span>
   </a>
-  <a href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer">
-    <img src="/assets/images/hucc.png">
+  <a href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer"
+     title="Hanyang University Cryptography Club"
+     class="cna-footer-pill">
+    <i class="fas fa-graduation-cap" style="font-size:18px;"></i>
+    <span>HUCC</span>
   </a>
 </p>
+
+<style>
+.cna-footer-pill{
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--cna-line);
+  border-radius: 999px;
+  color: var(--cna-ink);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--cna-paper);
+  transition: border-color .18s ease, color .18s ease;
+}
+.cna-footer-pill:hover{
+  border-color: var(--cna-indigo-line);
+  color: var(--cna-indigo);
+}
+</style>
 
 <script>
 (function () {


### PR DESCRIPTION
## Summary

Two small follow-ups to the design-refresh PR (#2) that were not included in that merge:

1. **Add a lab GitHub link to the footer.** A pill-shaped badge linking to https://github.com/Cryptology-Algorithm-Lab, placed to the left of the existing HUCC club link. Uses the FontAwesome github octocat icon next to the org name "Cryptology-Algorithm-Lab" so the affiliation is explicit (not just a generic GitHub icon).

2. **Match the HUCC club link to the same pill style** so the two footer affiliations are visually consistent. HUCC keeps its own link target; just the styling now uses the shared `.cna-footer-pill` class with a `fa-graduation-cap` icon + "HUCC" label.

Both pills share padding, border, radius, font size, and hover transition (border + text color → indigo) — extracted into a single CSS class so future footer affiliations can drop in cleanly.

## Files changed

- `_includes/footer/custom.html` — both pills + a small `<style>` block defining `.cna-footer-pill`

## Test plan

- [ ] Pull the branch and run `bundle exec jekyll serve`
- [ ] Scroll to the footer of any page — confirm two pill-shaped links sit side by side (GitHub on the left, HUCC on the right)
- [ ] Hover each pill — border and text should tint indigo
- [ ] Click each pill — opens its respective target in a new tab (the global external-link JS already adds target=_blank)