### PR TITLE
Footer pills: scale up 1.4x and add margin to copyright row

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,37 +1,59 @@
 <!-- start custom footer snippets -->
-<p align="right" style="display:flex; justify-content:flex-end; align-items:center; gap:12px; margin:0;">
+<div class="cna-footer-pills">
   <a href="https://github.com/Cryptology-Algorithm-Lab" target="_blank" rel="noopener noreferrer"
      title="Cryptology & Algorithm Lab on GitHub"
      class="cna-footer-pill">
-    <i class="fab fa-github" style="font-size:18px;"></i>
+    <i class="fab fa-github"></i>
     <span>Cryptology-Algorithm-Lab</span>
   </a>
   <a href="https://sites.google.com/view/hucc/" target="_blank" rel="noopener noreferrer"
      title="Hanyang University Cryptography Club"
      class="cna-footer-pill">
-    <i class="fas fa-graduation-cap" style="font-size:18px;"></i>
+    <i class="fas fa-graduation-cap"></i>
     <span>HUCC</span>
   </a>
-</p>
+</div>
 
 <style>
+.cna-footer-pills{
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 14px;
+  margin: 0 0 22px 0;     /* breathing room before the copyright/social row */
+  flex-wrap: wrap;
+}
 .cna-footer-pill{
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
+  gap: 10px;
+  padding: 12px 20px;     /* 1.4x: was 8 / 14 */
   border: 1px solid var(--cna-line);
   border-radius: 999px;
   color: var(--cna-ink);
   text-decoration: none;
-  font-size: 14px;
+  font-size: 17px;        /* 1.3x: was 14 */
   font-weight: 600;
   background: var(--cna-paper);
-  transition: border-color .18s ease, color .18s ease;
+  transition: border-color .18s ease, color .18s ease, transform .18s ease;
+}
+.cna-footer-pill i{
+  font-size: 22px;        /* 1.3x: was 18 */
+  line-height: 1;
 }
 .cna-footer-pill:hover{
   border-color: var(--cna-indigo-line);
   color: var(--cna-indigo);
+  transform: translateY(-1px);
+}
+@media (max-width: 600px){
+  .cna-footer-pills{
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 18px;
+  }
+  .cna-footer-pill{ padding: 10px 16px; font-size: 15px; }
+  .cna-footer-pill i{ font-size: 19px; }
 }
 </style>
 


### PR DESCRIPTION
## Summary

Follow-up polish to the footer GitHub / HUCC pill links that landed in PR #3. Two small tweaks per user feedback that the pills felt slightly small and crowded the copyright text below them.

## Changes

- **Pill sizing scaled ~1.3-1.4x**:
  - padding `8×14px` → `12×20px`
  - font-size `14px` → `17px`
  - icon size `18px` → `22px`
  - inner gap `8px` → `10px`
  - between-pill gap `12px` → `14px`
- **Margin to row below**: pills now sit in a `.cna-footer-pills` container with explicit `margin-bottom: 22px` so the copyright / social-icons row underneath has breathing room.
- **Hover lift**: now that the pills are big enough for motion to read as intentional, hover adds `translateY(-1px)` in addition to the indigo color tint.
- **Mobile (<600px)**: pills center-align and shrink slightly so they don't crowd the narrow viewport.

## Files changed

- `_includes/footer/custom.html` (1 file, +30/-8)

## Test plan

- [ ] Pull and run `bundle exec jekyll serve`
- [ ] Scroll to footer on any page — pills should be visibly larger and the copyright line should sit comfortably below with whitespace
- [ ] Hover each pill — border + text → indigo, plus subtle 1px upward lift
- [ ] Narrow the browser to <600px — pills should center and shrink slightly