### PR TITLE
Hero eyebrow: switch absolute positioning to normal flow for mobile wrap

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -959,24 +959,33 @@ body{
    chips, publication aside widen, seminar TBA cleanup.
    ────────────────────────────────────────────────────────── */
 
-/* (#2) Hero — pull title size down, add an uppercase eyebrow above */
+/* (#2) Hero — pull title size down, add an uppercase eyebrow above.
+   round-12 fix: eyebrow used to be absolutely positioned with a fixed
+   padding-top on the title. On mobile (<600px) the long eyebrow wraps
+   to 2 lines and overlaps the title because the padding doesn't grow.
+   Switch to normal flow + explicit margin-bottom so the title pushes
+   down based on the eyebrow's actual height when wrapped. */
 .page__hero--overlay .page__title{
   font-size: 2rem !important;
   font-weight: 800;
   letter-spacing: -.01em;
-  position: relative;
-  padding-top: var(--cna-s-5);
 }
 .page__hero--overlay .page__title::before{
   content: "Cryptology & Algorithm Lab · Hanyang University";
   display: block;
-  position: absolute;
-  top: 0; left: 0; right: 0;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: .2em;
   text-transform: uppercase;
   opacity: .85;
+  margin-bottom: var(--cna-s-3);
+  line-height: 1.5;
+}
+@media (max-width: 600px){
+  .page__hero--overlay .page__title::before{
+    letter-spacing: .12em;       /* tighter tracking so it fits one line on most phones */
+    margin-bottom: var(--cna-s-2);
+  }
 }
 /* (round-8 reversion: keep the eyebrow on homepage too — user
    liked having the lab full name + Hanyang University there.) */


### PR DESCRIPTION
## Summary

The hero eyebrow line `CRYPTOLOGY & ALGORITHM LAB · HANYANG UNIVERSITY` (visible above every page title) was positioned absolutely with a fixed 20px padding-top on the title. That works on desktop where the eyebrow stays one line, but on mobile (< 600px) the line wraps to 2 lines and the title's fixed padding-top no longer compensates — so the eyebrow's second row overlaps the title.

## Fix

In `_includes/head/custom.html`:

- Drop `position: absolute` (and the title's `position: relative` + `padding-top: var(--cna-s-5)` compensation)
- Eyebrow is now a block element in normal flow with `margin-bottom: 12px` (8px on mobile)
- Title pushes down naturally based on the eyebrow's wrapped height
- Mobile (< 600px) also gets tighter letter-spacing (.2em → .12em) so the line is more likely to fit one row on common phone widths

## Test plan

- [ ] Pull + `bundle exec jekyll serve`
- [ ] Open any page on desktop — eyebrow on top, title below, clear gap
- [ ] Resize browser to ~ 400px width or open dev tools mobile preview
- [ ] Confirm eyebrow wraps to 2 lines without overlapping the title; clear breathing room between
- [ ] Confirm the title still reads as the primary heading

## Files

- `_includes/head/custom.html` (+12 / -5)