### PR TITLE
Add adaptive black/white SVG favicon (CA monogram tile)

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,10 +1,13 @@
 <!-- start custom head snippets -->
 
-<!-- favicon — indigo 'C' on a rounded square (matches the design-system --cna-indigo accent) -->
+<!-- favicon — black/white 'CA' monogram tile, adaptive via prefers-color-scheme.
+     Light mode: dark tile + white letters. Dark mode: flipped.
+     Ampersand dropped — at 16×16 favicon size 3 glyphs + & become illegible. -->
 <link rel="icon" type="image/svg+xml" href="{{ '/assets/images/favicon.svg' | relative_url }}">
 <link rel="alternate icon" href="{{ '/assets/images/favicon.svg' | relative_url }}">
 <link rel="apple-touch-icon" href="{{ '/assets/images/favicon.svg' | relative_url }}">
-<meta name="theme-color" content="#2B5285">
+<meta name="theme-color" content="#0F1115" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: dark)">
 
 <!-- ============================================================
      C&A Lab Design System v1  (2026-05-23)

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,6 +1,10 @@
 <!-- start custom head snippets -->
 
-<!-- insert favicons. use https://realfavicongenerator.net/ -->
+<!-- favicon — indigo 'C' on a rounded square (matches the design-system --cna-indigo accent) -->
+<link rel="icon" type="image/svg+xml" href="{{ '/assets/images/favicon.svg' | relative_url }}">
+<link rel="alternate icon" href="{{ '/assets/images/favicon.svg' | relative_url }}">
+<link rel="apple-touch-icon" href="{{ '/assets/images/favicon.svg' | relative_url }}">
+<meta name="theme-color" content="#2B5285">
 
 <!-- ============================================================
      C&A Lab Design System v1  (2026-05-23)

--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#2B5285"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-size="40" font-weight="700" fill="#FFFFFF" letter-spacing="-2">C</text>
+</svg>

--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,6 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#2B5285"/>
-  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
-        font-family="Georgia, 'Times New Roman', serif"
-        font-size="40" font-weight="700" fill="#FFFFFF" letter-spacing="-2">C</text>
+  <style>
+    .tile { fill: #0F1115; }
+    .mark { fill: #FFFFFF; }
+    @media (prefers-color-scheme: dark) {
+      .tile { fill: #FFFFFF; }
+      .mark { fill: #0F1115; }
+    }
+  </style>
+  <rect class="tile" width="64" height="64" rx="14"/>
+  <text class="mark"
+        x="32" y="32"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Pretendard', 'Noto Sans KR', Arial, sans-serif"
+        font-size="38"
+        font-weight="900"
+        letter-spacing="-3">CA</text>
 </svg>


### PR DESCRIPTION
## Summary

The site had no favicon — browser tabs, bookmarks, and mobile home-screen saves all showed the blank/default icon. This PR adds an adaptive SVG favicon.

## Design (per UX review)

A heavy black-and-white **'CA' monogram on a rounded-square tile** that auto-flips with the system color scheme:

- 🌞 Light mode: dark tile `#0F1115` + white 'CA'
- 🌙 Dark mode: white tile + dark 'CA'

The ampersand was intentionally dropped — at 16×16 favicon size, three glyphs with a complex `&` collapse into illegible mush. The literal 'C&A' wordmark still appears in the site title, header, and footer pill where it has room to breathe. The favicon's job is silhouette recognition at a glance.

**Why a tile (not just letters)**: gives the mark its own contrast field, so it survives any browser-tab chrome color (Chrome white, Firefox dark, Arc sepia, etc.), not only the pure black/white extremes that `prefers-color-scheme` matches.

**Why heavy bold sans-serif** (`font-weight: 900, letter-spacing: -3`): matches the user's 고딕 (Korean for sans-serif) request and gives the cleanest 16×16 silhouette.

## Files

- `assets/images/favicon.svg` (new, ~330 bytes)
- `_includes/head/custom.html` — replace the `<!-- insert favicons -->` placeholder with proper `<link rel='icon'>` + `apple-touch-icon` + color-scheme-scoped `theme-color` meta tags

## Test plan

- [ ] Pull + `bundle exec jekyll serve`
- [ ] Open any page — browser tab should show the dark 'CA' tile (light mode) or white tile with dark 'CA' (dark mode)
- [ ] Toggle system color scheme — favicon flips automatically
- [ ] Bookmark the homepage — bookmark icon should be the 'CA' tile
- [ ] On mobile, 'Add to Home Screen' should show the same monogram
- [ ] Mobile Chrome address bar should tint to match the color scheme

## Future

If a dedicated lab logo is designed later, swap `assets/images/favicon.svg` in place — no other config changes needed. PNG fallbacks (`favicon-32.png`, `apple-touch-icon-180.png`) can be added later if older Safari / feed-reader compatibility becomes an issue.