### PR TITLE
Fix Annual News card top-right meta to announcement date (Taeho Jung)

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
   <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-seminar">Seminar</span>
-      <time class="cna-card-meta">May 29, 2026</time>
+      <time class="cna-card-meta">May 23, 2026</time>
     </header>
     <div class="cna-card-body">
       <p>Prof. Taeho Jung from the University of Notre Dame will visit the C&amp;A Lab for an academic exchange and research collaboration.</p>


### PR DESCRIPTION
## Summary

The Annual News card's top-right `<time class=\"cna-card-meta\">` represents the **announcement / posting date** (when the news was added). The actual **event date** lives inside the card body's `Date & Place` sub-bullet.

The Taeho Jung visit card was added on **2026-05-23** to announce a future visit on **2026-05-29**. Its top-right meta was set to May 29 (the event date) — fix to May 23 (the announcement date) so it matches the convention used by every other card.

| Card | Meta (announce) | Body event |
|---|---|---|
| Yongha Son visit | May 20 | May 21 |
| Hyeonmin/Ingeun joined | May 4 | — |
| Keewoo Lee visited | Apr 20 | Apr 20 |
| SilverMask accepted | Apr 13 | — |
| **Taeho Jung visit** | ~~May 29~~ → **May 23** | May 29 |

## Files

- `index.md` — one-line change to the Taeho Jung card's `<time class=\"cna-card-meta\">`