### PR TITLE
Add slides link: Ingeun Yun — Ch 2&3 Probability (Probabilistic ML Study, May 21)

### DIFF
--- a/index.md
+++ b/index.md
@@ -272,7 +272,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-seminar">May 21 · 17:30–19:30</span>
-          <span class="cna-card-meta cna-tba">TBA</span>
+          <a class="cna-card-meta" href="https://drive.google.com/file/d/11zY_N-jzwvL1t2WvEp7CU43cXT2GPFKk/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
           <b>Ch 2 &amp; 3 · Probability: Univariate &amp; Multivariate Models</b><br>

--- a/index.md
+++ b/index.md
@@ -287,7 +287,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
         </header>
         <div class="cna-card-body">
           <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
-          <span style="color:var(--cna-soft)">Insoo Kim · Place TBA</span>
+          <span style="color:var(--cna-soft)">Insoo Kim · Natural Building 702</span>
         </div>
       </article>
 


### PR DESCRIPTION
## Summary

The May 21 session of the 2026 Probabilistic ML Study Group (Ingeun Yun presenting *Ch 2 & 3: Probability — Univariate & Multivariate Models*) was held; this PR replaces the placeholder TBA on the session card with the actual slides link.

## Change

`index.md` — one line in the May 21 session card:

```diff
- <span class="cna-card-meta cna-tba">TBA</span>
+ <a class="cna-card-meta" href="https://drive.google.com/file/d/11zY_N-jzwvL1t2WvEp7CU43cXT2GPFKk/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
```

Matches the existing `Slides ↗` pattern used by every other seminar session card with materials.