### PR TITLE
Announce online lecture: Prof. Taechan Kim (Gachon, Zoom — Jun 1)

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,6 +28,19 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
   <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-seminar">Seminar</span>
+      <time class="cna-card-meta">May 31, 2026</time>
+    </header>
+    <div class="cna-card-body">
+      <p>Prof. Taechan Kim from the Department of Artificial Intelligence, Gachon University will give an online lecture to the C&amp;A Lab.</p>
+      <ul>
+        <li>Date &amp; Place: 04:00 PM, Jun 1 / Online (Zoom)</li>
+      </ul>
+    </div>
+  </article>
+
+  <article class="cna-card cna-cat-seminar">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-seminar">Seminar</span>
       <time class="cna-card-meta">May 23, 2026</time>
     </header>
     <div class="cna-card-body">


### PR DESCRIPTION
## Summary

New visiting seminar announcement (online via Zoom).

| Field | Value |
|---|---|
| Speaker | Prof. Taechan Kim (김태찬 교수) |
| Affiliation | Department of Artificial Intelligence, Gachon University |
| Date | Mon, June 1, 2026 / 04:00 PM |
| Format | Online — Zoom |

Inserted as the first `.cna-card` in Annual News on `index.md`, using `cna-cat-seminar` (plum). Top-right `<time class=\"cna-card-meta\">` set to the announcement date (May 31). Body `Date & Place` carries the actual event time/place per the established meta-vs-event convention.

## Change

`index.md` — one new `<article class=\"cna-card cna-cat-seminar\">` block added above the Taeho Jung card.