### PR TITLE
PML Study Group: split Ch 2&3 into Part 1+2, shift remaining sessions back 1 week

### DIFF
--- a/index.md
+++ b/index.md
@@ -299,7 +299,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
           <a class="cna-card-meta" href="https://drive.google.com/file/d/11zY_N-jzwvL1t2WvEp7CU43cXT2GPFKk/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
-          <b>Ch 2 &amp; 3 · Probability — Part 1</b><br>
+          <b>Ch 2 &amp; 3 · Probability: Univariate &amp; Multivariate Models</b><br>
           <span style="color:var(--cna-soft)">Ingeun Yun · Natural Building 702</span>
         </div>
       </article>
@@ -310,8 +310,8 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
-          <b>Ch 2 &amp; 3 · Probability — Part 2</b><br>
-          <span style="color:var(--cna-soft)">Ingeun Yun · Natural Building 702</span>
+          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory — Part 1</b><br>
+          <span style="color:var(--cna-soft)">Insoo Kim · Natural Building 702</span>
         </div>
       </article>
 
@@ -321,7 +321,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
-          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
+          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory — Part 2</b><br>
           <span style="color:var(--cna-soft)">Insoo Kim · Place TBA</span>
         </div>
       </article>

--- a/index.md
+++ b/index.md
@@ -264,7 +264,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 <details class="cna-year" open markdown="0">
   <summary>
     <h3>2026 · Spring · Probabilistic ML Study Group</h3>
-    <span class="cna-year-count">12 sessions</span>
+    <span class="cna-year-count">13 sessions</span>
     <svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg>
   </summary>
   <div class="cna-year-body">
@@ -299,7 +299,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
           <a class="cna-card-meta" href="https://drive.google.com/file/d/11zY_N-jzwvL1t2WvEp7CU43cXT2GPFKk/view?usp=sharing" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
-          <b>Ch 2 &amp; 3 · Probability: Univariate &amp; Multivariate Models</b><br>
+          <b>Ch 2 &amp; 3 · Probability — Part 1</b><br>
           <span style="color:var(--cna-soft)">Ingeun Yun · Natural Building 702</span>
         </div>
       </article>
@@ -310,14 +310,25 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
-          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
-          <span style="color:var(--cna-soft)">Insoo Kim · Natural Building 702</span>
+          <b>Ch 2 &amp; 3 · Probability — Part 2</b><br>
+          <span style="color:var(--cna-soft)">Ingeun Yun · Natural Building 702</span>
         </div>
       </article>
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-seminar">Jun 4 · 17:30–19:30</span>
+          <span class="cna-card-meta cna-tba">TBA</span>
+        </header>
+        <div class="cna-card-body">
+          <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory</b><br>
+          <span style="color:var(--cna-soft)">Insoo Kim · Place TBA</span>
+        </div>
+      </article>
+
+      <article class="cna-card cna-cat-seminar">
+        <header class="cna-card-head">
+          <span class="cna-chip cna-chip-seminar">Jun 11 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -328,7 +339,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jun 11 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 18 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -339,7 +350,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jun 18 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jun 25 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -350,7 +361,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jun 25 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 2 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -361,7 +372,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jul 2 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 9 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -372,7 +383,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jul 9 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 16 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -383,7 +394,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jul 16 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 23 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">
@@ -394,7 +405,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
-          <span class="cna-chip cna-chip-seminar">Jul 23 · 17:30–19:30</span>
+          <span class="cna-chip cna-chip-seminar">Jul 30 · 17:30–19:30</span>
           <span class="cna-card-meta cna-tba">TBA</span>
         </header>
         <div class="cna-card-body">


### PR DESCRIPTION
## Summary

Ingeun Yun's Ch 2 & 3 (Probability — Univariate & Multivariate Models) covered more than one session's worth of material, so this week (May 28) becomes Part 2 of the same chapters with the same presenter. Every subsequent session in the Probabilistic ML Study Group shifts back by one week, and a new Jul 30 session is appended to fit the final chapters.

## Schedule diff

| Date | Was | Now |
|---|---|---|
| May 21 | Ch 2&3 · Probability (Ingeun Yun) | **Ch 2&3 — Part 1** (Ingeun Yun) — title only, slides intact |
| May 28 | Ch 4&6 · Statistics (Insoo Kim) | **Ch 2&3 — Part 2** (Ingeun Yun) — same room NB 702 |
| Jun 4 | Ch 9&10 · LDA & Logistic (Hyeonmin Jang) | Ch 4&6 · Statistics (Insoo Kim) |
| Jun 11 | Ch 11 · Linear Regression (Shinwoong Kwak) | Ch 9&10 · LDA & Logistic (Hyeonmin Jang) |
| Jun 18 | Ch 13 · NN Tabular (Ingeun Yun) | Ch 11 · Linear Regression (Shinwoong Kwak) |
| Jun 25 | Ch 14 · NN Images (Insoo Kim) | Ch 13 · NN Tabular (Ingeun Yun) |
| Jul 2 | Ch 15 · NN Sequences (Hyeonmin Jang) | Ch 14 · NN Images (Insoo Kim) |
| Jul 9 | Ch 17 · Kernel Methods (Minsu Kim) | Ch 15 · NN Sequences (Hyeonmin Jang) |
| Jul 16 | Ch 19 · Few Labels (Shinwoong Kwak) | Ch 17 · Kernel Methods (Minsu Kim) |
| Jul 23 | Ch 20&21 · DimRed & Clustering (Minsu Kim) | Ch 19 · Few Labels (Shinwoong Kwak) |
| **Jul 30** | — | **Ch 20&21 · DimRed & Clustering (Minsu Kim) — NEW** |

Year-count chip bumped: `12 sessions` → `13 sessions`. All venues left as `Place TBA` for shifted sessions; only the two confirmed Ingeun Yun May sessions keep `Natural Building 702`.