### PR TITLE
Add talk title to Prof. Taechan Kim's Jun 1 seminar card

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,6 +34,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <p>Prof. Taechan Kim from the Department of Artificial Intelligence, Gachon University will give an online lecture to the C&amp;A Lab.</p>
       <ul>
         <li>Date &amp; Place: 04:00 PM, Jun 1 / Online (Zoom)</li>
+        <li>Title: Invisible Image Watermarks: From Pixel-level to Semantic Watermark</li>
       </ul>
     </div>
   </article>


### PR DESCRIPTION
## Summary

Add the title of Prof. Taechan Kim's upcoming lecture (Jun 1, 16:00, Zoom) to the existing Annual News seminar card.

| Field | Value |
|---|---|
| Speaker | Prof. Taechan Kim (Gachon University) |
| Date | Mon, June 1, 2026 / 04:00 PM |
| Format | Zoom |
| **Title** | **Invisible Image Watermarks: From Pixel-level to Semantic Watermark** |

## Change

`index.md` — added a `<li>Title: …</li>` line inside the existing Taechan Kim card's `<ul>`, matching the two-bullet (Date&Place + Title) structure used on the Yongha Son and Keewoo Lee cards.