### PR TITLE
Announce: Sunpill Kim + Minsu Kim selected for AI Seoul Tech Research Support 2026

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,6 +25,16 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
 <div class="cna-card-grid" markdown="0">
 
+  <article class="cna-card cna-cat-event">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-event">Program</span>
+      <time class="cna-card-meta">May 31, 2026</time>
+    </header>
+    <div class="cna-card-body">
+      <b>Sunpill Kim</b> (postdoc) and <b>Minsu Kim</b> (graduate student) have been selected for the <a href="https://www.seoulfuture.or.kr/home/kor/M075356964/scholarship/info/view.do?idx=cb00d1a0008a85e71a41b8741facbffe0da50bb4e2a1672fcc14ff2318200bfa">AI Seoul Tech Research Support Project 2026</a>, by the Seoul Future Foundation (Seoul Metropolitan Government).
+    </div>
+  </article>
+
   <article class="cna-card cna-cat-seminar">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-seminar">Seminar</span>

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <time class="cna-card-meta">May 31, 2026</time>
     </header>
     <div class="cna-card-body">
-      <b>Sunpill Kim</b> (postdoc) and <b>Minsu Kim</b> (graduate student) have been selected for the <a href="https://www.seoulfuture.or.kr/home/kor/M075356964/scholarship/info/view.do?idx=cb00d1a0008a85e71a41b8741facbffe0da50bb4e2a1672fcc14ff2318200bfa">AI Seoul Tech Research Support Project 2026</a>, by the Seoul Future Foundation (Seoul Metropolitan Government).
+      <b>Sunpill Kim</b> (postdoc) and <b>Minsu Kim</b> (graduate student) have been selected for the AI Seoul Tech Research Support Project 2026, by the Seoul Future Foundation (Seoul Metropolitan Government).
     </div>
   </article>
 

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
   <article class="cna-card cna-cat-event">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-event">Program</span>
-      <time class="cna-card-meta">May 31, 2026</time>
+      <time class="cna-card-meta">Jun 5, 2026</time>
     </header>
     <div class="cna-card-body">
       <b>Sunpill Kim</b> (postdoc) and <b>Minsu Kim</b> (graduate student) have been selected for the AI Seoul Tech Research Support Project 2026, by the Seoul Future Foundation (Seoul Metropolitan Government).


### PR DESCRIPTION
## Summary

Two lab members were selected for the **2026 AI Seoul Tech Research Support Project** (AI서울테크연구지원사업) by the Seoul Future Foundation (서울미래인재재단), funded by the Seoul Metropolitan Government:

| Track | Selected |
|---|---|
| 박사후연구원 (postdoc) | **Sunpill Kim** |
| 박사과정 (graduate student) | **Minsu Kim** |

Source: https://www.seoulfuture.or.kr/home/kor/M075356964/scholarship/info/view.do?idx=cb00d1a0008a85e71a41b8741facbffe0da50bb4e2a1672fcc14ff2318200bfa

## Change

`index.md` — new `<article class=\"cna-card cna-cat-event\">` inserted as the first card in Annual News, using the same Program/cna-chip-event (amber) pattern as the existing Yunki Kim NACET card. Selection announcement carries May 31, 2026 as the top-right meta (announcement date).