### PR TITLE
AI Seoul Tech card: chip text Program → Grant

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
   <article class="cna-card cna-cat-event">
     <header class="cna-card-head">
-      <span class="cna-chip cna-chip-event">Program</span>
+      <span class="cna-chip cna-chip-event">Grant</span>
       <time class="cna-card-meta">Jun 5, 2026</time>
     </header>
     <div class="cna-card-body">


### PR DESCRIPTION
## Summary

Follow-up to #14. The AI Seoul Tech Research Support Project is research funding (\$), not a training/curriculum program — relabel the chip to "Grant" for accuracy. Container class (`cna-cat-event`, amber) unchanged; the amber bucket already covers Workshop / Grant / Program / Fellowship per the design system.

The Yunki Kim NACET card stays as "Program" — that one is a training program, so the distinction now reads correctly across both cards.

## Change

`index.md` — one word in the AI Seoul Tech card chip span.