### PR TITLE
Seminar slides: Insoo Kim — Ch 4&6 Statistics (Part 1 + Part 2)

### DIFF
--- a/index.md
+++ b/index.md
@@ -318,7 +318,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-seminar">May 28 · 17:30–19:30</span>
-          <span class="cna-card-meta cna-tba">TBA</span>
+          <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1Yn5Ouej0l7vvjw4NUlwyWYn0iT79iZ_2/edit?slide=id.p1#slide=id.p1" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
           <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory — Part 1</b><br>
@@ -329,7 +329,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
       <article class="cna-card cna-cat-seminar">
         <header class="cna-card-head">
           <span class="cna-chip cna-chip-seminar">Jun 4 · 17:30–19:30</span>
-          <span class="cna-card-meta cna-tba">TBA</span>
+          <a class="cna-card-meta" href="https://docs.google.com/presentation/d/1Yn5Ouej0l7vvjw4NUlwyWYn0iT79iZ_2/edit?slide=id.p1#slide=id.p1" target="_blank" rel="noopener">Slides ↗</a>
         </header>
         <div class="cna-card-body">
           <b>Ch 4 &amp; 6 · Statistics &amp; Information Theory — Part 2</b><br>


### PR DESCRIPTION
## Summary

Replace the TBA placeholders on Insoo Kim's two-part PML Study Group sessions with the actual presentation slides link.

| Session | Date | Status |
|---|---|---|
| Ch 4 & 6 · Statistics &amp; Information Theory — **Part 1** | May 28 | TBA → Slides ↗ |
| Ch 4 & 6 · Statistics &amp; Information Theory — **Part 2** | Jun 4 | TBA → Slides ↗ |

Single deck covers both weeks (the speaker spread one chapter set across two sessions). Same URL on both card metas.

## Change

`index.md` — two `<span class="cna-card-meta cna-tba">TBA</span>` → `<a class="cna-card-meta" href="..." target="_blank" rel="noopener">Slides ↗</a>` swaps inside the Spring · Probabilistic ML Study Group section.