### PR TITLE
Announce paper acceptance: Seunghun Paik + Chanwoo Hwang (co-first) at IEEE SPL

### DIFF
--- a/_pages/Publication.md
+++ b/_pages/Publication.md
@@ -19,8 +19,20 @@ header:
 <h2 id="journal">Journal</h2>
 
 <details class="cna-year" open markdown="0">
-  <summary><h3>2026</h3><span class="cna-year-count">2 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
+  <summary><h3>2026</h3><span class="cna-year-count">3 papers</span><svg class="cna-year-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"/></svg></summary>
   <div class="cna-year-body">
+
+  <article class="cna-row">
+    <span class="cna-row-meta">J35</span>
+    <div class="cna-row-main">
+      <div class="cna-row-title"><b>Seunghun Paik&dagger;</b>, <b>Chanwoo Hwang&dagger;</b>, and <b>Jae Hong Seo*</b></div>
+      <div class="cna-row-sub"><i>Towards Generating Unlearnable Examples for Open-Set Face Recognition</i></div>
+    </div>
+    <div class="cna-row-aside">
+      <span class="cna-chip cna-chip-paper">IEEE SPL</span>
+      <span class="cna-row-aside-detail">TBA</span>
+    </div>
+  </article>
 
   <article class="cna-row">
     <span class="cna-row-meta">J34</span>

--- a/index.md
+++ b/index.md
@@ -25,6 +25,18 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
 <div class="cna-card-grid" markdown="0">
 
+  <article class="cna-card cna-cat-paper">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-paper">Journal</span>
+      <time class="cna-card-meta">Jun 5, 2026</time>
+    </header>
+    <div class="cna-card-body">
+      <p>Accepted for publication at <b>IEEE Signal Processing Letters</b>.</p>
+      <p><b>Seunghun Paik&dagger;</b>, <b>Chanwoo Hwang&dagger;</b>, and <b>Jae Hong Seo*</b><br>
+      <i>Towards Generating Unlearnable Examples for Open-Set Face Recognition</i></p>
+    </div>
+  </article>
+
   <article class="cna-card cna-cat-event">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-event">Grant</span>


### PR DESCRIPTION
## Summary

Paper acceptance announcement (Journal track) — IEEE Signal Processing Letters.

| Field | Value |
|---|---|
| Title | Towards Generating Unlearnable Examples for Open-Set Face Recognition |
| Authors | Seunghun Paik (co-first), Chanwoo Hwang (co-first), Jae Hong Seo (corresponding) |
| Venue | IEEE Signal Processing Letters (SPL) |
| Announcement date | 2026-06-05 |

## Changes (paper-accepted workflow — two files)

1. **`index.md`** (Annual News, top of grid):
   - New `.cna-card cna-cat-paper` (crimson) with "Journal" chip
   - Co-first authors marked with `&dagger;`, corresponding with `*`
2. **`_pages/Publication.md`** (Journal section, 2026 cluster):
   - New `J35` row at the top
   - IEEE SPL venue chip
   - Year-count chip `2 papers` → `3 papers`

DOI / journal volume info to be filled in later (currently `TBA`).