### PR TITLE
Fix SPL paper card announcement date: Jun 5 → Jun 11, 2026

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
   <article class="cna-card cna-cat-paper">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-paper">Journal</span>
-      <time class="cna-card-meta">Jun 5, 2026</time>
+      <time class="cna-card-meta">Jun 11, 2026</time>
     </header>
     <div class="cna-card-body">
       <p>Accepted for publication at <b>IEEE Signal Processing Letters</b>.</p>


### PR DESCRIPTION
## Summary

Single-character date correction on the Annual News card for the IEEE SPL paper acceptance.

| Field | Before | After |
|---|---|---|
| \`<time class=\"cna-card-meta\">\` | Jun 5, 2026 | **Jun 11, 2026** |

The previous value reused a stale in-session date instead of the actual announcement date (Jun 11, 2026 — when the acceptance notice was received).

Per the announcement-date convention: card top-right meta = the date the news became known to the lab, NOT the event/publication date.

## Affected

- \`index.md\` — Annual News (Journal card, top of grid)
- Publications page J35 row is unaffected (no date field — only year cluster \`2026\`).