### PR TITLE
Announce invited lecture: Prof. Taeho Jung (Notre Dame) — PIR &amp; TEE, Jun 15

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,6 +25,20 @@ We are Cryptology &amp; Algorithm Lab and our leader is Professor [Jae Hong Seo]
 
 <div class="cna-card-grid" markdown="0">
 
+  <article class="cna-card cna-cat-seminar">
+    <header class="cna-card-head">
+      <span class="cna-chip cna-chip-seminar">Seminar</span>
+      <time class="cna-card-meta">Jun 12, 2026</time>
+    </header>
+    <div class="cna-card-body">
+      <p>Prof. Taeho Jung from the Department of Computer Science and Engineering, University of Notre Dame will give an invited lecture at the C&amp;A Lab.</p>
+      <ul>
+        <li>Date &amp; Place: 01:00 PM, Jun 15 / Natural Science Building 702</li>
+        <li>Title: The Future of Practical Cryptography &mdash; PIR &amp; TEE</li>
+      </ul>
+    </div>
+  </article>
+
   <article class="cna-card cna-cat-paper">
     <header class="cna-card-head">
       <span class="cna-chip cna-chip-paper">Journal</span>


### PR DESCRIPTION
## Summary

New Annual News card for an invited lecture by Prof. Taeho Jung (University of Notre Dame).

| Field | Value |
|---|---|
| Speaker | Prof. Taeho Jung — Department of Computer Science and Engineering, University of Notre Dame |
| Title | The Future of Practical Cryptography — PIR & TEE |
| Date & Place | 01:00 PM, Jun 15, 2026 / Natural Science Building 702 |
| Announcement date | 2026-06-12 |

## Changes

- `index.md` — new `.cna-card cna-cat-seminar` (plum) inserted at the top of the Annual News grid

## Notes

- Prof. Taeho Jung previously visited the lab on May 29 (announced May 23 — already on the grid). This new card covers a separate invited-lecture event on Jun 15 with its own topic.
- Uses the standard seminar card layout: speaker intro paragraph + `<ul>` with Date & Place + Title (matching the prior Taechan Kim card convention).